### PR TITLE
アウトプット一覧機能のサーバーサイド

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@
 # 実装予定の機能
 
 # データベース設計
-
 ## usersテーブル
 |Column|Type|Options|
 |------|----|-------|
@@ -54,29 +53,46 @@
 |email|string|null: false, unique: true|
 |encrypted_password|string|null: false|
 |avatar||ActiveStorageで実装|
+その他devise_auth_tokenのデフォルトのカラム
 
 ### Associations
-- has_many :books
+- has_many :user_books
+- has_many :books, through: :user_books
 - has_many  :likes
 
 ## booksテーブル
 |Column|Type|Options|
 |------|----|-------|
+|isbn|string|null: false, unique: true|
 |title|string|null: false|
-|recommends|string|null: false|
-|description|text|null: false|
 |author|string|null: false|
-|publisher|string|null: false|
-|genre_id|integer|null: false ※ActiveHashを用いて実装|
-|price|integer|null: false|
-|amazon_link|text||
-|image||ActiveStorageで実装|
+|author_kana|string|null: false|
+|publisher_name|string|null: false|
+|sales_date|string|null: false|
+|item_price|integer|null: false|
+|item_url|text|null: false|
+|image_url|text|null: false|
+
+### Associations
+- has_many :user_books
+- has_many :users, through: :user_books
+- has_many :likes
+
+### 補足
+isbnは世界の書籍を識別するコード。同じ本であるかどうかを判定するのに用いる
+
+## user_booksテーブル
+|Column|Type|Options|
+|------|----|-------|
+|book|references|null: false, foreign_key: true|
+|user|references|null: false, foreign_key: true|
 
 ### Associations
 - belongs_to :user
-- has_many :likes
+- belongs_to :book
 
-## likesテーブル
+
+## likesテーブル(未実装)
 |Column|Type|Options|
 |------|----|-------|
 |book|references|null: false, foreign_key: true|
@@ -89,14 +105,27 @@
 - belongs_to :user
 - has_one :action_plan
 
+## awarenessesテーブル
+|Column|Type|Options|
+|------|----|-------|
+|content|string|null: false|
+|user|references|null: false, foreign_key: true|
+|book|references|null: false, foreign_key: true|
+
+### Associations
+- belongs_to :book
+- belongs_to :user
+- has_many :action_plans
+
 ## action_plansテーブル
 |Column|Type|Options|
 |------|----|-------|
-|like|references|null: false, foreign_key: true|
-|realizations|text|null: false|
-|action_plans|text|null: false|
+|time_of_execution|string|null: false|
+|what_to_do|string|null: false|
+|how_to_do|string||
+|awareness|references|null: false, foreign_key: true|
 
 ### Associations
-- belongs_to :like
+- belongs_to :awareness
 
 # ローカルでの動作方法

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -24,7 +24,7 @@ module Api
 
         user_book_relation = UserBook.find_by(user_id: @user.id, book_id: params[:book_id]) #ユーザーが書籍を投稿していない場合に処理を失敗させるために中間テーブルを参照
         if user_book_relation
-          outputs = Output.fetch_resources(user_book_relation.book.id)
+          outputs = Output.fetch_resources(user_book_relation.book.id) #fect_resourcesメソッドはoutput.rbにて定義
           render json: { outputs: outputs }
         else
           render status: 422, json: { errors: '書籍が推薦図書として追加されていません' } 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -18,6 +18,8 @@ module Api
         end
       end
 
+      
+
       def user_authentification
         # NewBookModal.jsxでLocalStorageからログインしているuidを抜き出し、request.headerに仕込む
         @user = User.find_for_database_authentication(uid: request.headers['uid'])

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -18,8 +18,19 @@ module Api
         end
       end
 
-      
+      def my_outputs
+        # ユーザー認証に引っかかった際のステータスは401(Unautorized)
+        return render status: 401, json: { errors: 'ユーザーが見つかりませんでした' } unless @user && @token && @client
 
+        user_book_relation = UserBook.find_by(user_id: @user.id, book_id: params[:book_id])
+        if user_book_relation
+          outputs = Output.fetch_resources(user_book_relation.book.id)
+          render json: { outputs: outputs }
+        else
+          render status: 422, json: { errors: '書籍が推薦図書として追加されていません' } 
+        end
+
+      end
       def user_authentification
         # NewBookModal.jsxでLocalStorageからログインしているuidを抜き出し、request.headerに仕込む
         @user = User.find_for_database_authentication(uid: request.headers['uid'])

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -22,7 +22,7 @@ module Api
         # ユーザー認証に引っかかった際のステータスは401(Unautorized)
         return render status: 401, json: { errors: 'ユーザーが見つかりませんでした' } unless @user && @token && @client
 
-        user_book_relation = UserBook.find_by(user_id: @user.id, book_id: params[:book_id])
+        user_book_relation = UserBook.find_by(user_id: @user.id, book_id: params[:book_id]) #ユーザーが書籍を投稿していない場合に処理を失敗させるために中間テーブルを参照
         if user_book_relation
           outputs = Output.fetch_resources(user_book_relation.book.id)
           render json: { outputs: outputs }

--- a/app/models/action_plan.rb
+++ b/app/models/action_plan.rb
@@ -1,6 +1,3 @@
 class ActionPlan < ApplicationRecord
-  has_many :book_action_plans
-  has_many :books, through: :book_action_plans
-  belongs_to :user
   belongs_to :awareness
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -16,6 +16,4 @@ class Book < ApplicationRecord
   has_many :user_books
   has_many :users, through: :user_books
   has_many :awarenesses
-  has_many :book_action_plans
-  has_many :action_plans, through: :action_plans
 end

--- a/app/models/book_action_plan.rb
+++ b/app/models/book_action_plan.rb
@@ -1,4 +1,0 @@
-class BookActionPlan < ApplicationRecord
-  belongs_to :book
-  belongs_to :action_plan
-end

--- a/app/models/output.rb
+++ b/app/models/output.rb
@@ -45,11 +45,11 @@ class Output
 
   def self.fetch_resources(book_id)
     book = Book.find(book_id)
-    outputs = []
-    output = {}
+    outputs = [] #アウトプットは複数投稿できるので配列で定義
+    output = {} #1つ1つのアウトプットはハッシュ形式
     book.awarenesses.each do |awareness|
       output[:awareness] = awareness
-      output[:action_plans] = awareness.action_plans
+      output[:action_plans] = awareness.action_plans #AwarenessとActionPlanで1対多のアソシエーションが組まれているのでこの書き方で参照可能
       outputs << output
     end
     return outputs

--- a/app/models/output.rb
+++ b/app/models/output.rb
@@ -52,6 +52,6 @@ class Output
       output[:action_plans] = awareness.action_plans #AwarenessとActionPlanで1対多のアソシエーションが組まれているのでこの書き方で参照可能
       outputs << output
     end
-    return outputs
+    return outputs #コントローラー側に戻り値として配列を返す
   end
 end

--- a/app/models/output.rb
+++ b/app/models/output.rb
@@ -43,4 +43,16 @@ class Output
     output[:action_plans] = action_plans
     output # 生成したハッシュをコントローラーに返し、レスポンスにする
   end
+
+  def self.fetch_resources(book_id)
+    book = Book.find(book_id)
+    outputs = []
+    output = {}
+    book.awarenesses.each do |awareness|
+      output[:awareness] = awareness
+      output[:action_plans] = awareness.action_plans
+      outputs << output
+    end
+    return outputs
+  end
 end

--- a/app/models/output.rb
+++ b/app/models/output.rb
@@ -33,9 +33,8 @@ class Output
     awareness.save
     action_plans.each do |action_plan|
       action_plan = ActionPlan.new(time_of_execution: action_plan[:time_of_execution], what_to_do: action_plan[:what_to_do],
-                                   how_to_do: action_plan[:how_to_do], book_id: book_id, user_id: user_id, awareness_id: awareness.id)
+                                   how_to_do: action_plan[:how_to_do], awareness_id: awareness.id)
       action_plan.save
-      BookActionPlan.create(book_id: book_id, action_plan_id: action_plan.id)
     end
     # 別々にレスポンスとして扱うためにハッシュ形式を採用(配列でもいけるが、なんのデータなのかわかりやすくしたい)
     output = {}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
         resources :outputs
       end
       get '/users/mypage', to: "users#show", as: :user_mypage #RESTではないがdevise_auth_tokenを用いる設計でidを使用せずuidを使用する関係でパスを独自に設定
+      get '/users/mypage/books/:book_id/outputs', to: "users#my_outputs", as: :user_outputs
     end
   end
   root 'homes#index'

--- a/db/migrate/20210413093533_create_action_plans.rb
+++ b/db/migrate/20210413093533_create_action_plans.rb
@@ -6,8 +6,6 @@ class CreateActionPlans < ActiveRecord::Migration[6.0]
       # how_to_doは必ずしも入力されない可能性が高いため必須としない
       t.string :how_to_do
       t.references :awareness, foreing_key: true
-      t.references :book, foreing_key: true
-      t.references :user, foreing_key: true
       t.timestamps
     end
   end

--- a/db/migrate/20210413214545_create_book_action_plans.rb
+++ b/db/migrate/20210413214545_create_book_action_plans.rb
@@ -1,9 +1,0 @@
-class CreateBookActionPlans < ActiveRecord::Migration[6.0]
-  def change
-    create_table :book_action_plans do |t|
-      t.references :book, foreing_key: true
-      t.references :action_plan, foreing_key: true
-      t.timestamps
-    end
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,20 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_13_214545) do
+ActiveRecord::Schema.define(version: 2021_04_13_093533) do
 
   create_table "action_plans", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "time_of_execution", null: false
     t.string "what_to_do", null: false
     t.string "how_to_do"
     t.bigint "awareness_id"
-    t.bigint "book_id"
-    t.bigint "user_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["awareness_id"], name: "index_action_plans_on_awareness_id"
-    t.index ["book_id"], name: "index_action_plans_on_book_id"
-    t.index ["user_id"], name: "index_action_plans_on_user_id"
   end
 
   create_table "active_storage_attachments", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -55,15 +51,6 @@ ActiveRecord::Schema.define(version: 2021_04_13_214545) do
     t.datetime "updated_at", precision: 6, null: false
     t.index ["book_id"], name: "index_awarenesses_on_book_id"
     t.index ["user_id"], name: "index_awarenesses_on_user_id"
-  end
-
-  create_table "book_action_plans", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "book_id"
-    t.bigint "action_plan_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["action_plan_id"], name: "index_book_action_plans_on_action_plan_id"
-    t.index ["book_id"], name: "index_book_action_plans_on_book_id"
   end
 
   create_table "books", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|

--- a/spec/models/output_spec.rb
+++ b/spec/models/output_spec.rb
@@ -5,13 +5,15 @@ RSpec.describe Output, type: :model do
   let(:book) { create(:book) }
   let(:output) { build(:output, user_id: user.id, book_id: book.id) }
 
+  # 異常形は3つ中1つ空のときのみ検証。それ以外のパターンはsystem_specにて
+
   describe 'アウトプットの保存' do
     context '保存に成功する時' do
       it 'すべての値が存在していれば保存できる' do
         expect(output).to be_valid
       end
       it 'どのように実践するか、は空でも保存できる' do
-        output.action_plans.each_with_index  do |_action_plan, index|
+        output.action_plans.each_with_index  do |action_plan, index|
           output.action_plans[index][:how_to_do] = ''
           expect(output).to be_valid
           output.action_plans[index][:how_to_do] = 'test' # これがないと空にした値が引き継がれてしまう
@@ -36,7 +38,7 @@ RSpec.describe Output, type: :model do
         expect(output.errors.full_messages).to include "Content of awareness can't be blank"
       end
       it 'アクションプランの何をやるか、が空欄のとき保存できない' do
-        output.action_plans.each_with_index do |_action_plan, index|
+        output.action_plans.each_with_index do |action_plan, index|
           output.action_plans[index][:what_to_do] = ''
           output.valid?
           expect(output.errors.full_messages).to include "What to do of action plan #{index + 1} can't be blank"
@@ -44,7 +46,7 @@ RSpec.describe Output, type: :model do
         end
       end
       it 'アクションプランのいつやるか、が空欄のとき保存できない' do
-        output.action_plans.each_with_index do |_action_plan, index|
+        output.action_plans.each_with_index do |action_plan, index|
           output.action_plans[index][:time_of_execution] = ''
           output.valid?
           expect(output.errors.full_messages).to include "Time of execution of action plan #{index + 1} can't be blank"

--- a/spec/models/output_spec.rb
+++ b/spec/models/output_spec.rb
@@ -66,7 +66,7 @@ RSpec.describe Output, type: :model do
         output.valid?
         expect(output.errors.full_messages).to include 'At least one action plan is required'
       end
-      it 'アクションプランが0個の時保存できない' do
+      it 'アクションプランが3つより多い時保存できない' do
         output.action_plans << output.action_plans[0]
         output.valid?
         expect(output.errors.full_messages).to include 'Action Plans are too many(maximum 3)'

--- a/spec/requests/outputs_spec.rb
+++ b/spec/requests/outputs_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe 'Outputs', type: :request do
       end
 
       it 'すべてのカラムが揃っていればレスポンスで気づきとアクションプランが得られる' do
-        output_params[:action_plans].each_with_index do |_action_plan, index|
+        output_params[:action_plans].each_with_index do |action_plan, index|
           post api_v1_book_outputs_path(book.id), xhr: true, params: { output: output_params }, headers: headers
           sleep 2 # sleepしないとレスポンスの返却が間に合わない
           json = JSON.parse(response.body)
@@ -61,7 +61,7 @@ RSpec.describe 'Outputs', type: :request do
       end
 
       it 'すべてのカラムが揃っていればレスポンスで気づきとアクションプランが得られる' do
-        output_params[:action_plans].each_with_index do |_action_plan, index|
+        output_params[:action_plans].each_with_index do |action_plan, index|
           post api_v1_book_outputs_path(book.id), xhr: true, params: { output: output_params }, headers: headers
           sleep 1 # sleepしないとレスポンスの返却が間に合わない
           json = JSON.parse(response.body)
@@ -91,7 +91,7 @@ RSpec.describe 'Outputs', type: :request do
       end
 
       it 'すべてのカラムが揃っていればレスポンスで気づきとアクションプランが得られる' do
-        output_params[:action_plans].each_with_index do |_action_plan, index|
+        output_params[:action_plans].each_with_index do |action_plan, index|
           post api_v1_book_outputs_path(book.id), xhr: true, params: { output: output_params }, headers: headers
           sleep 1 # sleepしないとレスポンスの返却が間に合わない
           json = JSON.parse(response.body)
@@ -141,7 +141,7 @@ RSpec.describe 'Outputs', type: :request do
     context '投稿に失敗する時' do
       # 個別のバリデーションの検証はmodel_psecにて。バリデーションはすべてpresence: true
       it '必須のカラムが不足している時保存に失敗しステータスが404になる' do
-        output_params[:action_plans].each_with_index do |_action_plan, index|
+        output_params[:action_plans].each_with_index do |action_plan, index|
           output_params[:action_plans][index][:what_to_do] = ''
           post api_v1_book_outputs_path(book.id), xhr: true, params: { output: output_params }, headers: headers
           expect(response).to have_http_status(422)
@@ -150,7 +150,7 @@ RSpec.describe 'Outputs', type: :request do
       end
 
       it '投稿に失敗するとAwarenessモデルのカウントが増えていない' do
-        output_params[:action_plans].each_with_index do |_action_plan, index|
+        output_params[:action_plans].each_with_index do |action_plan, index|
           output_params[:action_plans][index][:what_to_do] = ''
           expect do
             post api_v1_book_outputs_path(book.id), xhr: true, params: { output: output_params }, headers: headers
@@ -160,7 +160,7 @@ RSpec.describe 'Outputs', type: :request do
       end
 
       it '投稿に失敗するとActionPlanモデルのカウントが増えていない' do
-        output_params[:action_plans].each_with_index do |_action_plan, index|
+        output_params[:action_plans].each_with_index do |action_plan, index|
           output_params[:action_plans][index][:what_to_do] = ''
           expect do
             post api_v1_book_outputs_path(book.id), xhr: true, params: { output: output_params }, headers: headers
@@ -170,7 +170,7 @@ RSpec.describe 'Outputs', type: :request do
       end
 
       it '保存に失敗した時エラーメッセージがレスポンスとして返却される(何をやるか、が空欄)' do
-        output_params[:action_plans].each_with_index do |_action_plan, index|
+        output_params[:action_plans].each_with_index do |action_plan, index|
           output_params[:action_plans][index][:what_to_do] = ''
           post api_v1_book_outputs_path(book.id), xhr: true, params: { output: output_params }, headers: headers
           json = JSON.parse(response.body)
@@ -180,7 +180,7 @@ RSpec.describe 'Outputs', type: :request do
       end
 
       it '保存に失敗した時エラーメッセージがレスポンスとして返却される(いつやるか、が空欄)' do
-        output_params[:action_plans].each_with_index do |_action_plan, index|
+        output_params[:action_plans].each_with_index do |action_plan, index|
           output_params[:action_plans][index][:time_of_execution] = ''
           post api_v1_book_outputs_path(book.id), xhr: true, params: { output: output_params }, headers: headers
           json = JSON.parse(response.body)

--- a/spec/requests/outputs_spec.rb
+++ b/spec/requests/outputs_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe 'Outputs', type: :request do
     { 'uid' => user.uid, 'access-token' => 'ABCDEFGH12345678', 'client' => 'H-12345678' } # ユーザー認証用ヘッダ
   end
 
+  # 異常形は3つ中1つ空のときのみ検証。それ以外のパターンはsystem_specにて
+
   describe 'アウトプットの投稿' do
     context '投稿に成功する時' do
       before do

--- a/spec/requests/outputs_spec.rb
+++ b/spec/requests/outputs_spec.rb
@@ -125,7 +125,7 @@ RSpec.describe 'Outputs', type: :request do
         end.to change(Awareness, :count).by(1).and change(ActionPlan, :count).by(3) # andを使うことで複数のモデルの増減を同時に検証
       end
 
-      it 'すべてのカラムが揃っていればレスポンスで気づきとアクションプランが得られる' do
+      it 'レスポンスで気づきとアクションプランが得られる' do
         output_params[:action_plans].each_with_index do |action_plan, index|
           action_plan[:how_to_do] = '' # どのように実践するか、は空欄でOK
           post api_v1_book_outputs_path(book.id), xhr: true, params: { output: output_params }, headers: headers

--- a/spec/requests/outputs_spec.rb
+++ b/spec/requests/outputs_spec.rb
@@ -169,13 +169,23 @@ RSpec.describe 'Outputs', type: :request do
         end
       end
 
-      it '保存に失敗した時エラーメッセージがレスポンスとして返却される' do
+      it '保存に失敗した時エラーメッセージがレスポンスとして返却される(何をやるか、が空欄)' do
         output_params[:action_plans].each_with_index do |_action_plan, index|
           output_params[:action_plans][index][:what_to_do] = ''
           post api_v1_book_outputs_path(book.id), xhr: true, params: { output: output_params }, headers: headers
           json = JSON.parse(response.body)
           expect(json['errors']).to include "What to do of action plan #{index + 1} can't be blank"
           output_params[:action_plans][index][:what_to_do] = 'test' # これがないと空にした値が引き継がれてしまう
+        end
+      end
+
+      it '保存に失敗した時エラーメッセージがレスポンスとして返却される(いつやるか、が空欄)' do
+        output_params[:action_plans].each_with_index do |_action_plan, index|
+          output_params[:action_plans][index][:time_of_execution] = ''
+          post api_v1_book_outputs_path(book.id), xhr: true, params: { output: output_params }, headers: headers
+          json = JSON.parse(response.body)
+          expect(json['errors']).to include "Time of execution of action plan #{index + 1} can't be blank"
+          output_params[:action_plans][index][:time_of_execution] = 'test' # これがないと空にした値が引き継がれてしまう
         end
       end
     end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -210,14 +210,16 @@ RSpec.describe 'Users', type: :request do
     end
 
     context 'マイページの表示に失敗する' do
-      it 'ヘッダーのuidが存在しない時ステータスが404' do
+      before do
         headers['uid'] = nil
+      end
+      
+      it 'ヘッダーのuidが存在しない時ステータスが404' do
         get api_v1_user_mypage_path, xhr: true, headers: headers
         expect(response).to have_http_status(401)
       end
 
       it 'ヘッダーのuidが存在しない時レスポンスとしてエラーメッセージが返却される' do
-        headers['uid'] = nil
         get api_v1_user_mypage_path, xhr: true, headers: headers
         json = JSON.parse(response.body)
         expect(json['errors']).to eq 'ユーザーが見つかりませんでした'

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe 'Users', type: :request do
       before do
         user_book.user_id = user.id
         user_book.save #ユーザーと書籍の紐付け
-        output.book_id = user_book.book.id #アウトプットと書籍の紐付け
+        output.book_id = user_book.book.id #アウトプットとユーザーと書籍の紐付け
         @outputs = []
         # 2個保存することで複数データの取得が可能かどうか、順番は正しいかを検証
         2.times do 
@@ -251,7 +251,7 @@ RSpec.describe 'Users', type: :request do
         sleep 2 # sleepしないとレスポンスの返却が間に合わない
         json = JSON.parse(response.body)
         sleep 2
-        expect(json['outputs'].length).to eq 2
+        expect(json['outputs'].length).to eq 2 #beforeの部分で2個保存している
         json['outputs'].each_with_index do |output, output_index|
           expect(output['awareness']['content']).to eq @outputs[output_index][:awareness].content
           output['action_plans'].each_with_index do |action_plan, action_plan_index|
@@ -266,8 +266,7 @@ RSpec.describe 'Users', type: :request do
     context "アウトプット一覧の表示に成功する時(アウトプットが投稿されていない)" do
       before do
         user_book.user_id = user.id
-        user_book.save
-        # ユーザーと書籍は紐付いているがアウトプットは投稿されていない
+        user_book.save # ユーザーと書籍は紐付いているがアウトプットは投稿されていない
       end
       
       it "アウトプットが投稿されていない時レスポンスが0件になる" do
@@ -283,8 +282,7 @@ RSpec.describe 'Users', type: :request do
       before do
         user_book.user_id = user.id
         user_book.save
-        headers['uid'] = nil
-        # そもそもユーザーが存在しない
+        headers['uid'] = nil # そもそもユーザーが存在しない
       end
       
       it "ヘッダーのユーザーが存在しないときリクエストに失敗する" do
@@ -304,8 +302,7 @@ RSpec.describe 'Users', type: :request do
       before do
         user_book.user_id = user.id
         user_book.save
-        output.book_id = book.id
-        # アウトプットと書籍は紐付いているが、書籍とユーザーが紐付いていない
+        output.book_id = book.id  # アウトプットと書籍は紐付いているが、書籍とユーザーが紐付いていない
       end
       
       it "書籍が推薦図書として追加されていない場合、ステータスが422になる" do

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -231,9 +231,10 @@ RSpec.describe 'Users', type: :request do
     context "アウトプット一覧の表示に成功する時(アウトプット投稿済み)" do
       before do
         user_book.user_id = user.id
-        user_book.save
-        output.book_id = user_book.book.id
+        user_book.save #ユーザーと書籍の紐付け
+        output.book_id = user_book.book.id #アウトプットと書籍の紐付け
         @outputs = []
+        # 2個保存することで複数データの取得が可能かどうか、順番は正しいかを検証
         2.times do 
           output_save_result = output.save
           @outputs << output_save_result
@@ -266,6 +267,7 @@ RSpec.describe 'Users', type: :request do
       before do
         user_book.user_id = user.id
         user_book.save
+        # ユーザーと書籍は紐付いているがアウトプットは投稿されていない
       end
       
       it "アウトプットが投稿されていない時レスポンスが0件になる" do
@@ -282,6 +284,7 @@ RSpec.describe 'Users', type: :request do
         user_book.user_id = user.id
         user_book.save
         headers['uid'] = nil
+        # そもそもユーザーが存在しない
       end
       
       it "ヘッダーのユーザーが存在しないときリクエストに失敗する" do
@@ -302,6 +305,7 @@ RSpec.describe 'Users', type: :request do
         user_book.user_id = user.id
         user_book.save
         output.book_id = book.id
+        # アウトプットと書籍は紐付いているが、書籍とユーザーが紐付いていない
       end
       
       it "書籍が推薦図書として追加されていない場合、ステータスが422になる" do

--- a/spec/system/outputs_spec.rb
+++ b/spec/system/outputs_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'Outputs', type: :system, js: true do
   before do
     sign_in(user)
     create_list(:user_book, 2, user_id: user.id) 
+    sleep 2
     find('a', text: 'マイページ').click
     expect(page).to have_content "#{user.nickname}さんのマイページ"
     find('a', text: '推薦図書一覧').click
@@ -144,7 +145,10 @@ RSpec.describe 'Outputs', type: :system, js: true do
         click_button 'この内容で投稿する'
         sleep 3
       end.to change(Awareness, :count).by(0).and change(ActionPlan, :count).by(0)
-      expect(page).to have_content "Time of execution of action plan #{fill_empty_value_index + 1} can't be blank"
+
+      2.times do |error_message_index|
+        expect(page).to have_content "Time of execution of action plan #{error_message_index + 1} can't be blank"
+      end
     end
 
     it 'いつやるかが、3つ中1つ空のとき投稿に失敗し、エラーメッセージが表示される' do
@@ -170,11 +174,15 @@ RSpec.describe 'Outputs', type: :system, js: true do
     end
     
     it "いつやるかが、3つ中2つ空のとき投稿に失敗し、エラーメッセージが表示される" do
+      2.times do
+        click_button 'アクションプランを追加'
+      end
+
       3.times do |fill_form_index_for_two_values_empty_expectation|
         3.times do |fill_empty_value_index|
           # まず3つとも空にする
           fill_in "output_time_of_execution_#{fill_empty_value_index}",	with: ''
-        end
+        end  
         fill_in "output_time_of_execution_#{fill_form_index_for_two_values_empty_expectation}",
                 with: output.action_plans[fill_form_index_for_two_values_empty_expectation][:time_of_execution] # １つだけ入力する
                 fill_in "output_what_to_do_#{fill_form_index_for_two_values_empty_expectation}",
@@ -190,32 +198,35 @@ RSpec.describe 'Outputs', type: :system, js: true do
           expect(page).to  have_content "Time of execution of action plan #{test_index} can't be blank"
         end
       end
+    end
 
-      it 'いつやるかが、3つ中3つ空のとき投稿に失敗し、エラーメッセージが表示される' do
-        2.times do
-          click_button 'アクションプランを追加'
-        end
-  
-        3.times do |fill_form_index|
-          # まず3つとも値を入力する
-          fill_in "output_time_of_execution_#{fill_form_index}",	with: output.action_plans[fill_form_index][:time_of_execution]
-          fill_in "output_what_to_do_#{fill_form_index}",	with: output.action_plans[fill_form_index][:what_to_do]
-          fill_in "output_how_to_do_#{fill_form_index}",	with: output.action_plans[fill_form_index][:how_to_do]
-        end
-  
-        3.times do |fill_empty_value_index|
-          fill_in "output_time_of_execution_#{fill_empty_value_index}",	with: '' #3つとも空にする
-        end
+    it 'いつやるかが、3つ中3つ空のとき投稿に失敗し、エラーメッセージが表示される' do
+      2.times do
+        click_button 'アクションプランを追加'
+      end
 
-        expect do
-          click_button 'この内容で投稿する'
-          sleep 3
-        end.to change(Awareness, :count).by(0).and change(ActionPlan, :count).by(0)
-        expect(page).to have_content "Time of execution of action plan #{fill_empty_value_index + 1} can't be blank"
+      3.times do |fill_form_index|
+        # まず3つとも値を入力する
+        fill_in "output_time_of_execution_#{fill_form_index}",	with: output.action_plans[fill_form_index][:time_of_execution]
+        fill_in "output_what_to_do_#{fill_form_index}",	with: output.action_plans[fill_form_index][:what_to_do]
+        fill_in "output_how_to_do_#{fill_form_index}",	with: output.action_plans[fill_form_index][:how_to_do]
+      end
+
+      3.times do |fill_empty_value_index|
+        fill_in "output_time_of_execution_#{fill_empty_value_index}",	with: '' #3つとも空にする
+      end
+
+      expect do
+        click_button 'この内容で投稿する'
+        sleep 3
+      end.to change(Awareness, :count).by(0).and change(ActionPlan, :count).by(0)
+
+      3.times do |error_message_index|
+        expect(page).to have_content "Time of execution of action plan #{error_message_index + 1} can't be blank"
       end
     end
     
-    it '何をやるかが、2つ中1つ空のとき投稿に失敗し、エラーメッセージが表示される。また追加した入力欄は消えている' do
+    it '何をやるかが、2つ中1つ空のとき投稿に失敗し、エラーメッセージが表示される。' do
       # １つだけ空のとき
       click_button 'アクションプランを追加'
       2.times do |fill_form_index|
@@ -231,8 +242,9 @@ RSpec.describe 'Outputs', type: :system, js: true do
         end.to change(Awareness, :count).by(0).and change(ActionPlan, :count).by(0)
         expect(page).to have_content "What to do of action plan #{fill_empty_value_index + 1} can't be blank"
       end
+    end
 
-    it '何をやるかが、2つ中2つ空のとき投稿に失敗し、エラーメッセージが表示される。また追加した入力欄は消えている' do
+    it '何をやるかが、2つ中2つ空のとき投稿に失敗し、エラーメッセージが表示される' do
       # １つだけ空のとき
       click_button 'アクションプランを追加'
       2.times do |fill_form_index|
@@ -248,10 +260,14 @@ RSpec.describe 'Outputs', type: :system, js: true do
         click_button 'この内容で投稿する'
         sleep 3
       end.to change(Awareness, :count).by(0).and change(ActionPlan, :count).by(0)
-      expect(page).to have_content "What to do of action plan #{fill_empty_value_index + 1} can't be blank"
+
+      2.times do |error_message_index|
+        expect(page).to have_content "What to do of action plan #{error_message_index + 1} can't be blank"
+      end
+
     end
 
-    it '何をやるかが、3つ中1つ空のとき投稿に失敗し、エラーメッセージが表示される。また追加した入力欄は消えている' do
+    it '何をやるかが、3つ中1つ空のとき投稿に失敗し、エラーメッセージが表示される。' do
       # １つだけ空のとき
       2.times do
         click_button 'アクションプランを追加'
@@ -269,109 +285,114 @@ RSpec.describe 'Outputs', type: :system, js: true do
         end.to change(Awareness, :count).by(0).and change(ActionPlan, :count).by(0)
         expect(page).to have_content "What to do of action plan #{fill_empty_value_index + 1} can't be blank"
       end
+    end
 
-      
-      it '何をやるかが、3つ中2つ空のとき投稿に失敗し、エラーメッセージが表示される。また追加した入力欄は消えている' do
-        # 2つ空のとき
-        3.times do |fill_form_index_for_two_values_empty_expectation|
-          3.times do |fill_empty_value_index|
-            fill_in "output_what_to_do_#{fill_empty_value_index}",	with: ''
-        end
-        fill_in "output_time_of_execution_#{fill_form_index_for_two_values_empty_expectation}",
-        with: output.action_plans[fill_form_index_for_two_values_empty_expectation][:time_of_execution]
-        fill_in "output_what_to_do_#{fill_form_index_for_two_values_empty_expectation}",
-        with: output.action_plans[fill_form_index_for_two_values_empty_expectation][:time_of_execution]
-        fill_in "output_how_to_do_#{fill_form_index_for_two_values_empty_expectation}",
-        with: output.action_plans[fill_form_index_for_two_values_empty_expectation][:time_of_execution]
-        expect do
-          click_button 'この内容で投稿する'
-          sleep 3
-        end.to change(Awareness, :count).by(0).and change(ActionPlan, :count).by(0)
-        test_index_list = [1, 2, 3].reject { |index| index == fill_form_index_for_two_values_empty_expectation + 1 } # 入力されていないinpuタグの番号を抽出
-        test_index_list.each do |test_index|
-          expect(page).to  have_content "What to do of action plan #{test_index} can't be blank"
-        end
+    it '何をやるかが、3つ中2つ空のとき投稿に失敗し、エラーメッセージが表示される。' do
+      # 2つ空のとき
+      2.times do
+        click_button 'アクションプランを追加'
       end
 
-      it '何をやるかが、3つ中3つ空のとき投稿に失敗し、エラーメッセージが表示される。また追加した入力欄は消えている' do
-        2.times do
-          click_button 'アクションプランを追加'
-        end
-        3.times do |fill_form_index|
-          fill_in "output_time_of_execution_#{fill_form_index}",	with: output.action_plans[fill_form_index][:time_of_execution]
-          fill_in "output_what_to_do_#{fill_form_index}",	with: output.action_plans[fill_form_index][:what_to_do]
-          fill_in "output_how_to_do_#{fill_form_index}",	with: output.action_plans[fill_form_index][:how_to_do]
-        end
+      3.times do |fill_form_index_for_two_values_empty_expectation|
         3.times do |fill_empty_value_index|
           fill_in "output_what_to_do_#{fill_empty_value_index}",	with: ''
-        end
-        
-        expect do
-          click_button 'この内容で投稿する'
-          sleep 3
-        end.to change(Awareness, :count).by(0).and change(ActionPlan, :count).by(0)
-        expect(page).to have_content "What to do of action plan #{fill_empty_value_index + 1} can't be blank"
       end
-    end
-    
-    context 'モーダルの操作' do
-      it "入力内容はモーダルを閉じ再び開くと消える" do
-        fill_in 'output_content',	with: output.content
-        2.times do
-          click_button 'アクションプランを追加'
-        end
-        3.times do |fill_form_index|
-          fill_in "output_time_of_execution_#{fill_form_index}",	with: output.action_plans[fill_form_index][:time_of_execution]
-          fill_in "output_what_to_do_#{fill_form_index}",	with: output.action_plans[fill_form_index][:what_to_do]
-          fill_in "output_how_to_do_#{fill_form_index}",	with: output.action_plans[fill_form_index][:how_to_do]
-        end
-        click_button 'x' #モーダル外部をクリックしたときも挙動は同じ。
-        find('a', text: 'アウトプットを投稿する').click
-        # 入力値はあるけど値は空であること検証
-        expect(page).to have_field 'output_content', with: ''
-        expect(page).to have_field 'output_what_to_do_0', with: ''
-        expect(page).to have_field 'output_time_of_execution_0', with: ''
-        expect(page).to have_field 'output_how_to_do_0', with: ''
-        # 追加した入力欄は消えていることを検証
-        [1,2].each do |index|
-          expect(page).not_to have_field "output_what_to_do_#{index}"
-          expect(page).not_to have_field "output_time_of_execution_#{index}"
-          expect(page).not_to have_field "output_how_to_do_#{index}"
-        end
-      end
-
-      it "エラーメッセージはモーダルを閉じ再び開くと消える" do
-        fill_in 'output_content',	with: output.content
-        2.times do
-          click_button 'アクションプランを追加'
-        end
-        3.times do |fill_form_index|
-          fill_in "output_time_of_execution_#{fill_form_index}",	with: ""
-          fill_in "output_what_to_do_#{fill_form_index}",	with: ""
-          fill_in "output_how_to_do_#{fill_form_index}",	with: ""
-        end
+      fill_in "output_time_of_execution_#{fill_form_index_for_two_values_empty_expectation}",
+      with: output.action_plans[fill_form_index_for_two_values_empty_expectation][:time_of_execution]
+      fill_in "output_what_to_do_#{fill_form_index_for_two_values_empty_expectation}",
+      with: output.action_plans[fill_form_index_for_two_values_empty_expectation][:time_of_execution]
+      fill_in "output_how_to_do_#{fill_form_index_for_two_values_empty_expectation}",
+      with: output.action_plans[fill_form_index_for_two_values_empty_expectation][:time_of_execution]
+      expect do
         click_button 'この内容で投稿する'
         sleep 3
-        3.times do |error_message_index|
-          expect(page).to  have_content "Time of execution of action plan #{error_message_index + 1} can't be blank"
-          expect(page).to  have_content "What to do of action plan #{error_message_index + 1} can't be blank"
-        end
-        click_button 'x' #モーダル外部をクリックしたときも挙動は同じ
-        find('a', text: 'アウトプットを投稿する').click
-        3.times do |error_message_index|
-          expect(page).not_to  have_content "Time of execution of action plan #{error_message_index + 1} can't be blank"
-          expect(page).not_to  have_content "What to do of action plan #{error_message_index + 1} can't be blank"
-        end
+      end.to change(Awareness, :count).by(0).and change(ActionPlan, :count).by(0)
+      test_index_list = [1, 2, 3].reject { |index| index == fill_form_index_for_two_values_empty_expectation + 1 } # 入力されていないinpuタグの番号を抽出
+      test_index_list.each do |test_index|
+        expect(page).to  have_content "What to do of action plan #{test_index} can't be blank"
+      end
+    end
+  end
+    it '何をやるかが、3つ中3つ空のとき投稿に失敗し、エラーメッセージが表示される。' do
+      2.times do
+        click_button 'アクションプランを追加'
+      end
+      3.times do |fill_form_index|
+        fill_in "output_time_of_execution_#{fill_form_index}",	with: output.action_plans[fill_form_index][:time_of_execution]
+        fill_in "output_what_to_do_#{fill_form_index}",	with: output.action_plans[fill_form_index][:what_to_do]
+        fill_in "output_how_to_do_#{fill_form_index}",	with: output.action_plans[fill_form_index][:how_to_do]
+      end
+      3.times do |fill_empty_value_index|
+        fill_in "output_what_to_do_#{fill_empty_value_index}",	with: ''
       end
 
-      it "アクションプランが0個の時に取り消し操作をするとアラートが出て消せない" do
-        find('span', text: '取り消し').click
-        sleep 5
-        expect(page.driver.browser.switch_to.alert.text).to eq 'アクションプランは最低1つ必要です'
-        sleep 2
-        page.driver.browser.switch_to.alert.accept
-        expect(page).to  have_content 'アウトプットを投稿する' #モーダルにとどまることを検証
+      expect do
+        click_button 'この内容で投稿する'
+        sleep 3
+      end.to change(Awareness, :count).by(0).and change(ActionPlan, :count).by(0)
+
+      3.times do |error_message_index|
+        expect(page).to have_content "What to do of action plan #{error_message_index + 1} can't be blank"
       end
-    end  
+    end
   end
+  context 'モーダルの操作' do
+    it "入力内容はモーダルを閉じ再び開くと消える" do
+      fill_in 'output_content',	with: output.content
+      2.times do
+        click_button 'アクションプランを追加'
+      end
+      3.times do |fill_form_index|
+        fill_in "output_time_of_execution_#{fill_form_index}",	with: output.action_plans[fill_form_index][:time_of_execution]
+        fill_in "output_what_to_do_#{fill_form_index}",	with: output.action_plans[fill_form_index][:what_to_do]
+        fill_in "output_how_to_do_#{fill_form_index}",	with: output.action_plans[fill_form_index][:how_to_do]
+      end
+      click_button 'x' #モーダル外部をクリックしたときも挙動は同じ。
+      find('a', text: 'アウトプットを投稿する').click
+      # 入力値はあるけど値は空であること検証
+      expect(page).to have_field 'output_content', with: ''
+      expect(page).to have_field 'output_what_to_do_0', with: ''
+      expect(page).to have_field 'output_time_of_execution_0', with: ''
+      expect(page).to have_field 'output_how_to_do_0', with: ''
+      # 追加した入力欄は消えていることを検証
+      [1,2].each do |index|
+        expect(page).not_to have_field "output_what_to_do_#{index}"
+        expect(page).not_to have_field "output_time_of_execution_#{index}"
+        expect(page).not_to have_field "output_how_to_do_#{index}"
+      end
+    end
+
+    it "エラーメッセージはモーダルを閉じ再び開くと消える" do
+      fill_in 'output_content',	with: output.content
+      2.times do
+        click_button 'アクションプランを追加'
+      end
+      3.times do |fill_form_index|
+        fill_in "output_time_of_execution_#{fill_form_index}",	with: ""
+        fill_in "output_what_to_do_#{fill_form_index}",	with: ""
+        fill_in "output_how_to_do_#{fill_form_index}",	with: ""
+      end
+      click_button 'この内容で投稿する'
+      sleep 3
+      3.times do |error_message_index|
+        expect(page).to  have_content "Time of execution of action plan #{error_message_index + 1} can't be blank"
+        expect(page).to  have_content "What to do of action plan #{error_message_index + 1} can't be blank"
+      end
+      click_button 'x' #モーダル外部をクリックしたときも挙動は同じ
+      find('a', text: 'アウトプットを投稿する').click
+      3.times do |error_message_index|
+        expect(page).not_to  have_content "Time of execution of action plan #{error_message_index + 1} can't be blank"
+        expect(page).not_to  have_content "What to do of action plan #{error_message_index + 1} can't be blank"
+      end
+    end
+
+    it "アクションプランが0個の時に取り消し操作をするとアラートが出て消せない" do
+      find('span', text: '取り消し').click
+      sleep 5
+      expect(page.driver.browser.switch_to.alert.text).to eq 'アクションプランは最低1つ必要です'
+      sleep 2
+      page.driver.browser.switch_to.alert.accept
+      expect(page).to  have_content 'アウトプットを投稿する' #モーダルにとどまることを検証
+    end
+  end  
 end

--- a/spec/system/outputs_spec.rb
+++ b/spec/system/outputs_spec.rb
@@ -13,6 +13,7 @@ RSpec.describe 'Outputs', type: :system, js: true do
     find('a', text: '推薦図書一覧').click
     all('a', text: 'アウトプット')[0].click
     find('a', text: 'アウトプットを投稿する').click
+    expect(page).to  have_content 'アウトプットを投稿する'
   end
   
 
@@ -107,8 +108,46 @@ RSpec.describe 'Outputs', type: :system, js: true do
       expect(page).to have_content "Content of awareness can't be blank"
     end
 
-    it 'いつやるかが、一つでも空のとき投稿に失敗し、エラーメッセージが表示される' do
-      # １つだけ空のとき
+    it 'いつやるかが、2つ中1つ空のとき投稿に失敗し、エラーメッセージが表示される' do
+      click_button 'アクションプランを追加'
+      2.times do |fill_form_index|
+        # まず3つとも値を入力する
+        fill_in "output_time_of_execution_#{fill_form_index}",	with: output.action_plans[fill_form_index][:time_of_execution]
+        fill_in "output_what_to_do_#{fill_form_index}",	with: output.action_plans[fill_form_index][:what_to_do]
+        fill_in "output_how_to_do_#{fill_form_index}",	with: output.action_plans[fill_form_index][:how_to_do]
+      end
+
+      2.times do |fill_empty_value_index|
+        fill_in "output_time_of_execution_#{fill_empty_value_index}",	with: '' #1つだけ空にする
+        expect do
+          click_button 'この内容で投稿する'
+          sleep 3
+        end.to change(Awareness, :count).by(0).and change(ActionPlan, :count).by(0)
+        expect(page).to have_content "Time of execution of action plan #{fill_empty_value_index + 1} can't be blank"
+      end
+    end
+
+    it 'いつやるかが、2つ中2つ空のとき投稿に失敗し、エラーメッセージが表示される' do
+      click_button 'アクションプランを追加'
+      2.times do |fill_form_index|
+        # まず3つとも値を入力する
+        fill_in "output_time_of_execution_#{fill_form_index}",	with: output.action_plans[fill_form_index][:time_of_execution]
+        fill_in "output_what_to_do_#{fill_form_index}",	with: output.action_plans[fill_form_index][:what_to_do]
+        fill_in "output_how_to_do_#{fill_form_index}",	with: output.action_plans[fill_form_index][:how_to_do]
+      end
+
+      2.times do |fill_empty_value_index|
+        fill_in "output_time_of_execution_#{fill_empty_value_index}",	with: '' #2つとも空にする
+      end
+
+      expect do
+        click_button 'この内容で投稿する'
+        sleep 3
+      end.to change(Awareness, :count).by(0).and change(ActionPlan, :count).by(0)
+      expect(page).to have_content "Time of execution of action plan #{fill_empty_value_index + 1} can't be blank"
+    end
+
+    it 'いつやるかが、3つ中1つ空のとき投稿に失敗し、エラーメッセージが表示される' do
       2.times do
         click_button 'アクションプランを追加'
       end
@@ -128,8 +167,9 @@ RSpec.describe 'Outputs', type: :system, js: true do
         end.to change(Awareness, :count).by(0).and change(ActionPlan, :count).by(0)
         expect(page).to have_content "Time of execution of action plan #{fill_empty_value_index + 1} can't be blank"
       end
-
-      # 2つ空のとき
+    end
+    
+    it "いつやるかが、3つ中2つ空のとき投稿に失敗し、エラーメッセージが表示される" do
       3.times do |fill_form_index_for_two_values_empty_expectation|
         3.times do |fill_empty_value_index|
           # まず3つとも空にする
@@ -137,11 +177,11 @@ RSpec.describe 'Outputs', type: :system, js: true do
         end
         fill_in "output_time_of_execution_#{fill_form_index_for_two_values_empty_expectation}",
                 with: output.action_plans[fill_form_index_for_two_values_empty_expectation][:time_of_execution] # １つだけ入力する
-        fill_in "output_what_to_do_#{fill_form_index_for_two_values_empty_expectation}",
+                fill_in "output_what_to_do_#{fill_form_index_for_two_values_empty_expectation}",
                 with: output.action_plans[fill_form_index_for_two_values_empty_expectation][:time_of_execution]
-        fill_in "output_how_to_do_#{fill_form_index_for_two_values_empty_expectation}",
+                fill_in "output_how_to_do_#{fill_form_index_for_two_values_empty_expectation}",
                 with: output.action_plans[fill_form_index_for_two_values_empty_expectation][:time_of_execution]
-        expect do
+                expect do
           click_button 'この内容で投稿する'
           sleep 3
         end.to change(Awareness, :count).by(0).and change(ActionPlan, :count).by(0)
@@ -150,9 +190,68 @@ RSpec.describe 'Outputs', type: :system, js: true do
           expect(page).to  have_content "Time of execution of action plan #{test_index} can't be blank"
         end
       end
+
+      it 'いつやるかが、3つ中3つ空のとき投稿に失敗し、エラーメッセージが表示される' do
+        2.times do
+          click_button 'アクションプランを追加'
+        end
+  
+        3.times do |fill_form_index|
+          # まず3つとも値を入力する
+          fill_in "output_time_of_execution_#{fill_form_index}",	with: output.action_plans[fill_form_index][:time_of_execution]
+          fill_in "output_what_to_do_#{fill_form_index}",	with: output.action_plans[fill_form_index][:what_to_do]
+          fill_in "output_how_to_do_#{fill_form_index}",	with: output.action_plans[fill_form_index][:how_to_do]
+        end
+  
+        3.times do |fill_empty_value_index|
+          fill_in "output_time_of_execution_#{fill_empty_value_index}",	with: '' #3つとも空にする
+        end
+
+        expect do
+          click_button 'この内容で投稿する'
+          sleep 3
+        end.to change(Awareness, :count).by(0).and change(ActionPlan, :count).by(0)
+        expect(page).to have_content "Time of execution of action plan #{fill_empty_value_index + 1} can't be blank"
+      end
+    end
+    
+    it '何をやるかが、2つ中1つ空のとき投稿に失敗し、エラーメッセージが表示される。また追加した入力欄は消えている' do
+      # １つだけ空のとき
+      click_button 'アクションプランを追加'
+      2.times do |fill_form_index|
+        fill_in "output_time_of_execution_#{fill_form_index}",	with: output.action_plans[fill_form_index][:time_of_execution]
+        fill_in "output_what_to_do_#{fill_form_index}",	with: output.action_plans[fill_form_index][:what_to_do]
+        fill_in "output_how_to_do_#{fill_form_index}",	with: output.action_plans[fill_form_index][:how_to_do]
+      end
+      2.times do |fill_empty_value_index|
+        fill_in "output_what_to_do_#{fill_empty_value_index}",	with: ''
+        expect do
+          click_button 'この内容で投稿する'
+          sleep 3
+        end.to change(Awareness, :count).by(0).and change(ActionPlan, :count).by(0)
+        expect(page).to have_content "What to do of action plan #{fill_empty_value_index + 1} can't be blank"
+      end
+
+    it '何をやるかが、2つ中2つ空のとき投稿に失敗し、エラーメッセージが表示される。また追加した入力欄は消えている' do
+      # １つだけ空のとき
+      click_button 'アクションプランを追加'
+      2.times do |fill_form_index|
+        fill_in "output_time_of_execution_#{fill_form_index}",	with: output.action_plans[fill_form_index][:time_of_execution]
+        fill_in "output_what_to_do_#{fill_form_index}",	with: output.action_plans[fill_form_index][:what_to_do]
+        fill_in "output_how_to_do_#{fill_form_index}",	with: output.action_plans[fill_form_index][:how_to_do]
+      end
+      2.times do |fill_empty_value_index|
+        fill_in "output_what_to_do_#{fill_empty_value_index}",	with: ''
+      end
+
+      expect do
+        click_button 'この内容で投稿する'
+        sleep 3
+      end.to change(Awareness, :count).by(0).and change(ActionPlan, :count).by(0)
+      expect(page).to have_content "What to do of action plan #{fill_empty_value_index + 1} can't be blank"
     end
 
-    it '何をやるかが、一つでも空のとき投稿に失敗し、エラーメッセージが表示される。また追加した入力欄は消えている' do
+    it '何をやるかが、3つ中1つ空のとき投稿に失敗し、エラーメッセージが表示される。また追加した入力欄は消えている' do
       # １つだけ空のとき
       2.times do
         click_button 'アクションプランを追加'
@@ -171,17 +270,19 @@ RSpec.describe 'Outputs', type: :system, js: true do
         expect(page).to have_content "What to do of action plan #{fill_empty_value_index + 1} can't be blank"
       end
 
-      # 2つ空のとき
-      3.times do |fill_form_index_for_two_values_empty_expectation|
-        3.times do |fill_empty_value_index|
-          fill_in "output_what_to_do_#{fill_empty_value_index}",	with: ''
+      
+      it '何をやるかが、3つ中2つ空のとき投稿に失敗し、エラーメッセージが表示される。また追加した入力欄は消えている' do
+        # 2つ空のとき
+        3.times do |fill_form_index_for_two_values_empty_expectation|
+          3.times do |fill_empty_value_index|
+            fill_in "output_what_to_do_#{fill_empty_value_index}",	with: ''
         end
         fill_in "output_time_of_execution_#{fill_form_index_for_two_values_empty_expectation}",
-                with: output.action_plans[fill_form_index_for_two_values_empty_expectation][:time_of_execution]
+        with: output.action_plans[fill_form_index_for_two_values_empty_expectation][:time_of_execution]
         fill_in "output_what_to_do_#{fill_form_index_for_two_values_empty_expectation}",
-                with: output.action_plans[fill_form_index_for_two_values_empty_expectation][:time_of_execution]
+        with: output.action_plans[fill_form_index_for_two_values_empty_expectation][:time_of_execution]
         fill_in "output_how_to_do_#{fill_form_index_for_two_values_empty_expectation}",
-                with: output.action_plans[fill_form_index_for_two_values_empty_expectation][:time_of_execution]
+        with: output.action_plans[fill_form_index_for_two_values_empty_expectation][:time_of_execution]
         expect do
           click_button 'この内容で投稿する'
           sleep 3
@@ -191,9 +292,29 @@ RSpec.describe 'Outputs', type: :system, js: true do
           expect(page).to  have_content "What to do of action plan #{test_index} can't be blank"
         end
       end
-    end
 
-    context 'モーダルの開閉' do
+      it '何をやるかが、3つ中3つ空のとき投稿に失敗し、エラーメッセージが表示される。また追加した入力欄は消えている' do
+        2.times do
+          click_button 'アクションプランを追加'
+        end
+        3.times do |fill_form_index|
+          fill_in "output_time_of_execution_#{fill_form_index}",	with: output.action_plans[fill_form_index][:time_of_execution]
+          fill_in "output_what_to_do_#{fill_form_index}",	with: output.action_plans[fill_form_index][:what_to_do]
+          fill_in "output_how_to_do_#{fill_form_index}",	with: output.action_plans[fill_form_index][:how_to_do]
+        end
+        3.times do |fill_empty_value_index|
+          fill_in "output_what_to_do_#{fill_empty_value_index}",	with: ''
+        end
+        
+        expect do
+          click_button 'この内容で投稿する'
+          sleep 3
+        end.to change(Awareness, :count).by(0).and change(ActionPlan, :count).by(0)
+        expect(page).to have_content "What to do of action plan #{fill_empty_value_index + 1} can't be blank"
+      end
+    end
+    
+    context 'モーダルの操作' do
       it "入力内容はモーダルを閉じ再び開くと消える" do
         fill_in 'output_content',	with: output.content
         2.times do
@@ -242,7 +363,15 @@ RSpec.describe 'Outputs', type: :system, js: true do
           expect(page).not_to  have_content "What to do of action plan #{error_message_index + 1} can't be blank"
         end
       end
-    end
-    
+
+      it "アクションプランが0個の時に取り消し操作をするとアラートが出て消せない" do
+        find('span', text: '取り消し').click
+        sleep 5
+        expect(page.driver.browser.switch_to.alert.text).to eq 'アクションプランは最低1つ必要です'
+        sleep 2
+        page.driver.browser.switch_to.alert.accept
+        expect(page).to  have_content 'アウトプットを投稿する' #モーダルにとどまることを検証
+      end
+    end  
   end
 end


### PR DESCRIPTION
# 変更内容の説明
## サーバーサイド
- api/v1/users_controller.rbにてmy_outputアクションを定義。対応するルーティングを設定
- models/output.rbにてfetch_resourcesメソッドを定義

## テストコード
- requests/users_spec.rbにてアウトプット一覧表示のテストを実装

## 過去の変更内容の修正
- action_plansテーブルからuser_id、book_idカラムを削除
- book_action_plansテーブルを捨てる
- requests/outputs_spec.rbにて、異常形テストを追加
- system/outputs_spec.rbにて、異常形テストを追加
- README.mdに最新のDB設計を反映

# ユーザーストーリー
なし

# プルリク提出時の確認事項
下記全てにチェック（x）をつけてから提出しましょう。
## コーディングの品質向上
- [x] **1.コメント**：初心者エンジニアにも分かりやすいような、相手目線でのコメントを書いた。
- [x] **2.テスト**：ユースケースが追加/変更された場合は、それに対して変更に強いテストを書いた。
## プルリクの品質向上
- [x] **3.UIのキャプチャ**：UIに変更がある場合は、変更点が分かりやすく伝わるように、キャプチャを貼っている。