### PR TITLE
ユーザー情報編集機能のサーバーサイド

### DIFF
--- a/app/controllers/api/v1/users/registrations_controller.rb
+++ b/app/controllers/api/v1/users/registrations_controller.rb
@@ -27,31 +27,30 @@ module Api
           end
         end
 
-        def update
+        def update # rubocop:disable Metrics/PerceivedComplexity
           # ユーザー認証に引っかかった際のステータスは401(Unautorized)
           return render status: 401, json: { errors: 'ユーザーが存在しません' } unless @user && @token && @client
           
-          if params[:user]
-            if params[:user][:nickname].present? && params[:user][:avatar][:data].present? && params[:user][:avatar][:filename].present?
-              # 画像とnickname両方変更する場合
-              @user.avatar.detatch if @user.avatar.attached? #すでにavatarが紐付いていれば外す
-              update_nickname
-              avatar_attach
-            elsif params[:user][:nickname].present?
-              # ニックネームだけ変更する場合
-              update_nickname
-            elsif params[:user][:avatar][:data].present? && params[:user][:avatar][:filename].present?
-              # アバターだけ変更する場合
-              @user.avatar.detatch if @user.avatar.attached? #すでにavatarが紐付いていれば外す
-              avatar_attach
-            else
-              # アバターもニックネームも空で送られてきた場合
-              return render status: 422, json: { errors: ["Nickname can't be blank"] }
-            end
-            update_auth_header # access-token, clientの発行
-            # 最後に更新した結果をフロントに返す
-            return render json: { user: @user }  
+          return nil unless params[:user]
+          if params[:user][:nickname].present? && params[:user][:avatar][:data].present? && params[:user][:avatar][:filename].present?
+            # 画像とnickname両方変更する場合
+            @user.avatar.detatch if @user.avatar.attached? #すでにavatarが紐付いていれば外す
+            update_nickname
+            avatar_attach
+          elsif params[:user][:nickname].present?
+            # ニックネームだけ変更する場合
+            update_nickname
+          elsif params[:user][:avatar][:data].present? && params[:user][:avatar][:filename].present?
+            # アバターだけ変更する場合
+            @user.avatar.detatch if @user.avatar.attached? #すでにavatarが紐付いていれば外す
+            avatar_attach
+          else
+            # アバターもニックネームも空で送られてきた場合
+            return render status: 422, json: { errors: ["Nickname can't be blank"] }
           end
+          update_auth_header # access-token, clientの発行
+          # 最後に更新した結果をフロントに返す
+          return render json: { user: @user }  
         end
 
         private

--- a/app/controllers/api/v1/users/registrations_controller.rb
+++ b/app/controllers/api/v1/users/registrations_controller.rb
@@ -6,6 +6,8 @@ module Api
       class RegistrationsController < DeviseTokenAuth::RegistrationsController
         skip_before_action :verify_authenticity_token, only: [:create] # APIではCSRFチェックをしない
         skip_before_action :validate_account_update_params, only: :update # 自前でユーザー認証するので不要
+        skip_before_action :set_user_by_token, only: :update
+        skip_after_action :update_auth_header
         before_action :user_authentification, only: :update
         after_action :set_csrf_token_header # csrf-tokenの更新
 
@@ -28,8 +30,7 @@ module Api
         def update
           # ユーザー認証に引っかかった際のステータスは401(Unautorized)
           return render status: 401, json: { errors: 'ユーザーが存在しません' } unless @user && @token && @client
-
-
+          
           if params[:user]
             if params[:user][:nickname].present? && params[:user][:avatar][:data].present? && params[:user][:avatar][:filename].present?
               # 画像とnickname両方変更する場合

--- a/app/controllers/api/v1/users/registrations_controller.rb
+++ b/app/controllers/api/v1/users/registrations_controller.rb
@@ -5,6 +5,8 @@ module Api
     module Users
       class RegistrationsController < DeviseTokenAuth::RegistrationsController
         skip_before_action :verify_authenticity_token, only: [:create] # APIではCSRFチェックをしない
+        skip_before_action :validate_account_update_params, only: :update # 自前でユーザー認証するので不要
+        before_action :user_authentification, only: :update
         after_action :set_csrf_token_header # csrf-tokenの更新
 
         respond_to :json
@@ -28,7 +30,21 @@ module Api
         end
 
         def update
-          super
+          # ユーザー認証に引っかかった際のステータスは401(Unautorized)
+          return render status: 401, json: { errors: 'ユーザーが存在しません' } unless @user && @token && @client
+          if params[:user][:avatar][:data] != '' && params[:user][:avatar][:filename] != '' # 画像データ自体は送られてくるので中身が空かどうか判定をする
+            blob = ActiveStorage::Blob.create_after_upload!(
+              io: StringIO.new("#{decode(params[:user][:avatar][:data])}\n"), # UserModal.jsxでfilereaderを使って取得した文字列を復号する
+              filename: params[:user][:avatar][:filename] # filenameはUserModal.jsxで取得
+            )
+            @user.avatar.attach(blob) # 先に作っておいた画像とuserを紐付ける
+          end
+          if @user.update_attributes(nickname: params[:user][:nickname])
+            update_auth_header # access-token, clientの発行
+            render json: { user: @user }
+          else
+            render status: 422, json: { errors: @user.errors.full_messages } # バリデーションに引っかかった際のステータスは422(Unprocessable entity)
+          end
         end
 
         private
@@ -56,6 +72,14 @@ module Api
           else
             refresh_headers
           end
+        end
+
+        def user_authentification
+          # NewBookModal.jsxでLocalStorageからログインしているuidを抜き出し、request.headerに仕込む
+          @user = User.find_for_database_authentication(uid: request.headers['uid'])
+          # 同様にaccess-token, clientについてもrequest.headersから抜き出して変数に代入
+          @token = request.headers['access-token']
+          @client = request.headers['client']
         end
       end
     end

--- a/app/controllers/api/v1/users/registrations_controller.rb
+++ b/app/controllers/api/v1/users/registrations_controller.rb
@@ -27,7 +27,8 @@ module Api
           end
         end
 
-        def update # rubocop:disable Metrics/PerceivedComplexity
+        
+        def update # rubocop:disable Metrics/CyclomaticComplexity:, Metrics/PerceivedComplexity:
           # ユーザー認証に引っかかった際のステータスは401(Unautorized)
           return render status: 401, json: { errors: 'ユーザーが存在しません' } unless @user && @token && @client
           

--- a/app/controllers/api/v1/users/registrations_controller.rb
+++ b/app/controllers/api/v1/users/registrations_controller.rb
@@ -38,6 +38,7 @@ module Api
               filename: params[:user][:avatar][:filename] # filenameはUserModal.jsxで取得
             )
             @user.avatar.attach(blob) # 先に作っておいた画像とuserを紐付ける
+            return render json: { user: @user } if params[:user][:nickname] == ""
           end
           if @user.update_attributes(nickname: params[:user][:nickname])
             update_auth_header # access-token, clientの発行

--- a/app/controllers/api/v1/users/registrations_controller.rb
+++ b/app/controllers/api/v1/users/registrations_controller.rb
@@ -28,7 +28,7 @@ module Api
         end
 
         
-        def update # rubocop:disable Metrics/CyclomaticComplexity:, Metrics/PerceivedComplexity:
+        def update # rubocop:disable Metrics/CyclomaticComplexity, Metrics/PerceivedComplexity
           # ユーザー認証に引っかかった際のステータスは401(Unautorized)
           return render status: 401, json: { errors: 'ユーザーが存在しません' } unless @user && @token && @client
           

--- a/app/controllers/api/v1/users/registrations_controller.rb
+++ b/app/controllers/api/v1/users/registrations_controller.rb
@@ -27,6 +27,10 @@ module Api
           end
         end
 
+        def update
+          super
+        end
+
         private
 
         def sign_up_params

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -16,15 +16,22 @@ RSpec.describe 'Users', type: :request do
   end
   
   describe "ユーザー情報の更新" do
+    before do
+      user_params[:avatar] = { data: '', filename: '' } # 実行環境でも画像未選択の場合空文字列が送られる
+    end
+
     context "更新に成功する時" do
       it "パラメータが正しい時ユーザー情報の編集に成功する" do
+        user_params[:nickname] = 'updated'
+        patch api_v1_user_registration_path, xhr: true, headers: headers, params: { user: user_params }
+        
+        binding.pry
+        
         
       end
     end
-    
-    
   end
-  
+
   describe '新規登録' do
     before do
       user_params[:avatar] = { data: '', filename: '' } # 実行環境でも画像未選択の場合空文字列が送られる

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -24,10 +24,6 @@ RSpec.describe 'Users', type: :request do
       it "パラメータが正しい時ユーザー情報の編集に成功する" do
         user_params[:nickname] = 'updated'
         patch api_v1_user_registration_path, xhr: true, headers: headers, params: { user: user_params }
-        
-        binding.pry
-        
-        
       end
     end
   end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -14,7 +14,17 @@ RSpec.describe 'Users', type: :request do
   let(:headers) do
     { 'uid' => user.uid, 'access-token' => 'ABCDEFGH12345678', 'client' => 'H-12345678' }
   end
-
+  
+  describe "ユーザー情報の更新" do
+    context "更新に成功する時" do
+      it "パラメータが正しい時ユーザー情報の編集に成功する" do
+        
+      end
+    end
+    
+    
+  end
+  
   describe '新規登録' do
     before do
       user_params[:avatar] = { data: '', filename: '' } # 実行環境でも画像未選択の場合空文字列が送られる
@@ -319,4 +329,6 @@ RSpec.describe 'Users', type: :request do
       end
     end
   end
+
+  
 end

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -325,18 +325,18 @@ RSpec.describe 'Users', type: :request do
   
     context "更新に成功する時(nicknameのみ更新)" do
       it "パラメータが正しい時ステータスが200で返却される" do
-        put api_v1_user_registration_path, xhr: true, headers: headers, params: { user: {nickname: 'updated', avatar: { data: '', filename: '' } } } #paramsにはこれ以外の値は送信されない想定
+        put api_v1_user_registration_path, xhr: true, headers: headers, params: { user: {nickname: 'updated', avatar: { data: '', filename: '' } } } 
         expect(response).to have_http_status(200) # 成功時ステータスは200
       end
   
       it "リクエストに成功した場合ユーザーの数は増加しない" do
         expect do 
-          put api_v1_user_registration_path, xhr: true, headers: headers, params: { user: {nickname: 'updated', avatar: { data: '', filename: '' } } } #paramsにはこれ以外の値は送信されない想定
+          put api_v1_user_registration_path, xhr: true, headers: headers, params: { user: {nickname: 'updated', avatar: { data: '', filename: '' } } } 
         end.to change(User, :count)
       end
   
       it "パラメータが正しい時更新されたユーザーの情報がレスポンスとして返却される" do
-        put api_v1_user_registration_path, xhr: true, headers: headers, params: { user: {nickname: 'updated', avatar: { data: '', filename: '' } } } #paramsにはこれ以外の値は送信されない想定
+        put api_v1_user_registration_path, xhr: true, headers: headers, params: { user: {nickname: 'updated', avatar: { data: '', filename: '' } } } 
         json = JSON.parse(response.body)
         expect(json['user']['nickname']).to eq request.params[:user][:nickname] # 値が更新されているかどうか
         expect(json['user']['email']).to eq user.email # emailは更新されていない
@@ -346,7 +346,10 @@ RSpec.describe 'Users', type: :request do
   
     context "更新に成功する時(avatarのみ更新)" do
       it "パラメータが正しい時更新されたユーザーの情報がレスポンスとして返却される" do
-        put api_v1_user_registration_path, xhr: true, headers: headers, params: { user: { nickname: '', avatar: { data: File.read('spec/fixtures/test_avatar.png.bin'), filename: 'test_avatar.png' } } } #paramsにはこれ以外の値は送信されない想定
+        put api_v1_user_registration_path, 
+        xhr: true, 
+        headers: headers, 
+        params: { user: { nickname: '', avatar: { data: File.read('spec/fixtures/test_avatar.png.bin'), filename: 'test_avatar.png' } } } 
         json = JSON.parse(response.body)  
         # 更新していないカラムの情報が維持されているかどうか
         expect(json['user']['nickname']).to eq user.nickname
@@ -357,7 +360,10 @@ RSpec.describe 'Users', type: :request do
   
     context "更新に成功する時(nickname, avatarともに更新)" do
       it "パラメータが正しい時ユーザー情報の編集に成功する" do
-        put api_v1_user_registration_path, xhr: true, headers: headers, params: { user: {nickname: 'update', avatar: { data: File.read('spec/fixtures/test_avatar.png.bin'), filename: 'test_avatar.png' } } } #paramsにはこれ以外の値は送信されない想定
+        put api_v1_user_registration_path, 
+        xhr: true, 
+        headers: headers, 
+        params: { user: {nickname: 'update', avatar: { data: File.read('spec/fixtures/test_avatar.png.bin'), filename: 'test_avatar.png' } } } 
         json = JSON.parse(response.body)
         expect(json['user']['nickname']).to eq request.params[:user][:nickname] # 値が変更されているかどうか
         expect(json['user']['email']).to eq user.email # 更新していないカラムの情報が維持されているかどうか
@@ -368,24 +374,24 @@ RSpec.describe 'Users', type: :request do
     context "更新に失敗するする時" do
       it "ヘッダーのユーザー情報が存在しない場合リクエストに失敗する" do
         headers['uid'] = nil # そもそもユーザーが存在しない
-        put api_v1_user_registration_path, xhr: true, headers: headers, params: { user: {nickname: '', avatar: { data: '', filename: '' } } } #paramsにはこれ以外の値は送信されない想定
+        put api_v1_user_registration_path, xhr: true, headers: headers, params: { user: {nickname: '', avatar: { data: '', filename: '' } } } 
         expect(response).to have_http_status(401) # コントローラーで422を返すよう設定。レコードの処理に失敗する、という意味で422
       end
 
       it "ヘッダーのユーザー情報が存在しない場合エラーメッセージが返却される" do
         headers['uid'] = nil # そもそもユーザーが存在しない
-        put api_v1_user_registration_path, xhr: true, headers: headers, params: { user: {nickname: '', avatar: { data: '', filename: '' } } } #paramsにはこれ以外の値は送信されない想定
+        put api_v1_user_registration_path, xhr: true, headers: headers, params: { user: {nickname: '', avatar: { data: '', filename: '' } } } 
         json = JSON.parse(response.body)
         expect(json['errors']).to eq 'ユーザーが存在しません'
       end
 
       it "nicknameとavatarがともに空の場合リクエストに失敗する" do
-        put api_v1_user_registration_path, xhr: true, headers: headers, params: { user: {nickname: '', avatar: { data: '', filename: '' } } } #paramsにはこれ以外の値は送信されない想定
+        put api_v1_user_registration_path, xhr: true, headers: headers, params: { user: {nickname: '', avatar: { data: '', filename: '' } } } 
         expect(response).to have_http_status(422) # コントローラーで422を返すよう設定。レコードの処理に失敗する、という意味で422
       end
   
       it "nicknameとavatarがともに空の場合元のデータと同じレスポンスが返却される" do
-        put api_v1_user_registration_path, xhr: true, headers: headers, params: { user: {nickname: '', avatar: { data: '', filename: '' } } } #paramsにはこれ以外の値は送信されない想定
+        put api_v1_user_registration_path, xhr: true, headers: headers, params: { user: {nickname: '', avatar: { data: '', filename: '' } } } 
         # レスポンスの中身を検証
         json = JSON.parse(response.body)
         expect(json['errors']).to include "Nickname can't be blank"

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -366,6 +366,19 @@ RSpec.describe 'Users', type: :request do
     end
   
     context "更新に失敗するする時" do
+      it "ヘッダーのユーザー情報が存在しない場合リクエストに失敗する" do
+        headers['uid'] = nil # そもそもユーザーが存在しない
+        put api_v1_user_registration_path, xhr: true, headers: headers, params: { user: {nickname: '', avatar: { data: '', filename: '' } } } #paramsにはこれ以外の値は送信されない想定
+        expect(response).to have_http_status(401) # コントローラーで422を返すよう設定。レコードの処理に失敗する、という意味で422
+      end
+
+      it "ヘッダーのユーザー情報が存在しない場合エラーメッセージが返却される" do
+        headers['uid'] = nil # そもそもユーザーが存在しない
+        put api_v1_user_registration_path, xhr: true, headers: headers, params: { user: {nickname: '', avatar: { data: '', filename: '' } } } #paramsにはこれ以外の値は送信されない想定
+        json = JSON.parse(response.body)
+        expect(json['errors']).to eq 'ユーザーが存在しません'
+      end
+
       it "nicknameとavatarがともに空の場合リクエストに失敗する" do
         put api_v1_user_registration_path, xhr: true, headers: headers, params: { user: {nickname: '', avatar: { data: '', filename: '' } } } #paramsにはこれ以外の値は送信されない想定
         expect(response).to have_http_status(422) # コントローラーで422を返すよう設定。レコードの処理に失敗する、という意味で422

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe 'Users', type: :request do
     before do
       user_params[:avatar] = { data: '', filename: '' } # 実行環境でも画像未選択の場合空文字列が送られる
     end
-
+    
     context 'パラメータが正しい時' do
       it 'リクエストに成功する(画像なし)' do # 念の為画像ありなし検証してます
         post api_v1_user_registration_path, xhr: true, params: { user: user_params }
@@ -104,7 +104,7 @@ RSpec.describe 'Users', type: :request do
         post api_v1_user_session_path, xhr: true, params: { user: { email: user.email, password: '' } }
         expect(response).to have_http_status(401)
       end
-
+      
       it 'エラーメッセージが返却される' do
         post api_v1_user_session_path, xhr: true, params: { user: { email: user.email, password: '' } }
         json = JSON.parse(response.body)
@@ -160,13 +160,13 @@ RSpec.describe 'Users', type: :request do
         expect(json['books'].length).to eq 0
       end
     end
-
+    
     context '画像あり' do
       before do
         user.avatar.attach(fixture_file_upload('spec/fixtures/test_avatar.png', filename: 'test_avatar.png',
                                                                                 content_type: 'image/png'))
                                                                               end
-
+                                                                              
       it 'ヘッダーにuidがあればリクエストに成功する' do
         get api_v1_user_mypage_path, headers: headers # headersは認証用のヘッダー
         expect(response).to have_http_status(200)
@@ -263,7 +263,7 @@ RSpec.describe 'Users', type: :request do
         end
       end
     end
-
+    
     context 'アウトプット一覧の表示に成功する時(アウトプットが投稿されていない)' do
       before do
         user_book.user_id = user.id
@@ -348,8 +348,10 @@ RSpec.describe 'Users', type: :request do
       it "パラメータが正しい時更新されたユーザーの情報がレスポンスとして返却される" do
         put api_v1_user_registration_path, xhr: true, headers: headers, params: { user: { nickname: '', avatar: { data: File.read('spec/fixtures/test_avatar.png.bin'), filename: 'test_avatar.png' } } } #paramsにはこれ以外の値は送信されない想定
         json = JSON.parse(response.body)  
-        # json['user']['nickname']が空で返ってくるのでもしかすると更新に失敗している？
-        expect(json['avatar']['filename']).to eq request.params[:user][:avatar][:filename]
+        # 更新していないカラムの情報が維持されているかどうか
+        expect(json['user']['nickname']).to eq user.nickname
+        expect(json['user']['email']).to eq user.email 
+        expect(user.avatar.blob.filename).to eq 'test_avatar.png' # 値が変更されているかどうか
       end
     end
   
@@ -369,7 +371,7 @@ RSpec.describe 'Users', type: :request do
         expect(response).to have_http_status(422) # コントローラーで422を返すよう設定。レコードの処理に失敗する、という意味で422
       end
   
-      it "nicknameとavatarがともに空の場合エラーメッセージが返却される" do
+      it "nicknameとavatarがともに空の場合元のデータと同じレスポンスが返却される" do
         put api_v1_user_registration_path, xhr: true, headers: headers, params: { user: {nickname: '', avatar: { data: '', filename: '' } } } #paramsにはこれ以外の値は送信されない想定
         # レスポンスの中身を検証
         json = JSON.parse(response.body)


### PR DESCRIPTION
# 変更内容の説明
## サーバーサイド
- api/v1/users/registrations_controller.rbにupdateアクションを定義。またnicknameカラムの更新処理をupdate_nicknameメソッドとして分離
- api/v1/users/registrations_controller.rbに画像をユーザーと紐付ける処理をattach_avatarメソッドとしてprivate以下に分離

## テストコード
- requests/users_spec.rbにユーザー情報の更新についてのテストを実装

# ユーザーストーリー
特になし

# プルリク提出時の確認事項
下記全てにチェック（x）をつけてから提出しましょう。
## コーディングの品質向上
- [x] **1.コメント**：初心者エンジニアにも分かりやすいような、相手目線でのコメントを書いた。
- [x] **2.テスト**：ユースケースが追加/変更された場合は、それに対して変更に強いテストを書いた。
## プルリクの品質向上
- [x] **3.UIのキャプチャ**：UIに変更がある場合は、変更点が分かりやすく伝わるように、キャプチャを貼っている。