### PR TITLE
マイページで投稿した書籍を新しい順にする

### DIFF
--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -12,9 +12,9 @@ module Api
         if @user.avatar.attached? # 添付されていないときにエラーが出るのを防ぐ
           avatar_path = Rails.application.routes.url_helpers.rails_representation_url(@user.avatar.variant({}),
                                                                                       only_path: true)
-          render json: { user: @user, books: @user.books.order('created_at DESC'), avatar: avatar_path }
+          render json: { user: @user, books: @user.books.includes(:user_books).order('user_books.updated_at DESC'), avatar: avatar_path }
         else
-          render json: { user: @user, books: @user.books.order('created_at DESC') }
+          render json: { user: @user, books: @user.books.includes(:user_books).order('user_books.updated_at DESC') }
         end
       end
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -12,9 +12,9 @@ module Api
         if @user.avatar.attached? # 添付されていないときにエラーが出るのを防ぐ
           avatar_path = Rails.application.routes.url_helpers.rails_representation_url(@user.avatar.variant({}),
                                                                                       only_path: true)
-          render json: { user: @user, books: @user.books, avatar: avatar_path }
+          render json: { user: @user, books: @user.books.order('created_at DESC'), avatar: avatar_path }
         else
-          render json: { user: @user, books: @user.books }
+          render json: { user: @user, books: @user.books.order('created_at DESC') }
         end
       end
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -12,9 +12,9 @@ module Api
         if @user.avatar.attached? # 添付されていないときにエラーが出るのを防ぐ
           avatar_path = Rails.application.routes.url_helpers.rails_representation_url(@user.avatar.variant({}),
                                                                                       only_path: true)
-          render json: { user: @user, books: @user.books.includes(:user_books).order('user_books.updated_at DESC'), avatar: avatar_path }
+          render json: { user: @user, books: @user.books.includes(:user_books).order('user_books.created_at DESC'), avatar: avatar_path }
         else
-          render json: { user: @user, books: @user.books.includes(:user_books).order('user_books.updated_at DESC') }
+          render json: { user: @user, books: @user.books.includes(:user_books).order('user_books.created_at DESC') }
         end
       end
 

--- a/spec/requests/users_spec.rb
+++ b/spec/requests/users_spec.rb
@@ -199,7 +199,7 @@ RSpec.describe 'Users', type: :request do
       it 'ヘッダーにuidがあれば正しく書籍情報がレスポンスとして返却される' do
         get api_v1_user_mypage_path, headers: headers
         json = JSON.parse(response.body)
-        expect(json['books'][0]['title']).to eq user_book.book.title # booksは配列なので添字を使う
+        expect(json['books'][-1]['title']).to eq user_book.book.title # booksは配列なので添字を使う
       end
 
       it 'ヘッダーにuidがあれば正しくユーザー情報がレスポンスとして返却される' do

--- a/spec/system/outputs_spec.rb
+++ b/spec/system/outputs_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe 'Outputs', type: :system, js: true do
       find('.header-link', text: 'マイページ').click
       expect(page).to have_content "#{user.nickname}さんのマイページ"
       find('a', text: '推薦図書一覧').click
-      sleep 10
+      sleep 15
       all('a', text: 'アウトプット')[0].click
       sleep 10
       find('a', text: 'アウトプットを投稿する').click
@@ -151,7 +151,7 @@ RSpec.describe 'Outputs', type: :system, js: true do
           click_button 'この内容で投稿する'
           sleep 3
         end.to change(Awareness, :count).by(1).and change(ActionPlan, :count).by(1) # ユーザーや書籍との紐付も同時に検証する
-        expect(page).to have_content "『#{user.books[0].title}』のアウトプット"
+        expect(page).to have_content "『#{user.books[-1].title}』のアウトプット"
         sleep 5
         expect(all('.output-list-header').length).to eq 1 # アウトプットは1件
         expect(all('.action-plan > p').length).to eq 1 # アクションプランは1件
@@ -169,7 +169,7 @@ RSpec.describe 'Outputs', type: :system, js: true do
           click_button 'この内容で投稿する'
           sleep 3
         end.to change(Awareness, :count).by(1).and change(ActionPlan, :count).by(2)
-        expect(page).to have_content "『#{user.books[0].title}』のアウトプット"
+        expect(page).to have_content "『#{user.books[-1].title}』のアウトプット"
         sleep 5
         expect(all('.output-list-header').length).to eq 1 # アウトプットは1件
         expect(all('.action-plan > p').length).to eq 2 # アクションプランは2件
@@ -189,7 +189,7 @@ RSpec.describe 'Outputs', type: :system, js: true do
           click_button 'この内容で投稿する'
           sleep 3
         end.to change(Awareness, :count).by(1).and change(ActionPlan, :count).by(3)
-        expect(page).to have_content "『#{user.books[0].title}』のアウトプット"
+        expect(page).to have_content "『#{user.books[-1].title}』のアウトプット"
         sleep 5
         expect(all('.output-list-header').length).to eq 1 # アウトプットは1件
         expect(all('.action-plan > p').length).to eq 3 # アクションプランは3件

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -285,20 +285,24 @@ RSpec.describe 'Users', type: :system do
         end.to change(user.books, :count).by(1) # ユーザーと紐付いているかどうかも検証
         expect(page).not_to have_content '推薦図書を投稿する' # トップページに戻ることを検証
         click_link '推薦図書一覧'
-        expect(all('.book-list-item > .book-title')[-1].text).not_to eq 'test' # テストデータではない、つまり新しく追加したデータは一番うしろに追加される
+        expect(all('.book-list-item > .book-title')[0].text).not_to eq 'test' # テストデータではない、つまり新しく追加したデータは一番うしろに追加される
       end
     end
 
     context 'アウトプットが投稿されている時' do
-      it 'アウトプットが投稿されていればマイページでアウトプット一覧が参照できる' do
+      before do
+        # 事前準備なのでbeforeに移した
         user.save
         create_list(:user_book, 2, user_id: user.id)
         sleep 5
         # formオブジェクトではcreate_listが使えないのでちょっと回りくどく同じデータを複数個生成している
         3.times do
-          output = build(:output, user_id: user.id, book_id: user.books[0].id)
+          output = build(:output, user_id: user.id, book_id: user.books[-1].id)
           output.save
-        end
+        end  
+      end
+      
+      it 'アウトプットが投稿されていればマイページでアウトプット一覧が参照できる' do
         sign_in(user) # ログインする
         find('.header-link', text: 'マイページ').click
         expect(page).to have_content "#{user.nickname}さんのマイページ"
@@ -306,11 +310,11 @@ RSpec.describe 'Users', type: :system do
         sleep 10
         expect(all('.book-list-item').length).to eq user.books.length
         all('a', text: 'アウトプット')[0].click
-        expect(page).to have_content "『#{user.books[0].title}』のアウトプット"
+        expect(page).to have_content "『#{user.books[-1].title}』のアウトプット"
         sleep 5
         # アウトプットのリストに1個しかない要素
-        expect(all('.output-list-header').length).to eq user.books[0].awarenesses.length
-        expect(all('.awareness')[0].text).to eq user.books[0].awarenesses[-1].content # 一番新しいものが一番上に来る
+        expect(all('.output-list-header').length).to eq user.books[-1].awarenesses.length
+        expect(all('.awareness')[0].text).to eq user.books[-1].awarenesses[-1].content # 一番新しいものが一番上に来る
       end
     end
 


### PR DESCRIPTION
# 変更内容の説明
## サーバーサイド
- api/v1/users_controller.rbのshowアクションにてbooksの値を `@user.books` から `@user.books.includes(:user_books).order('user_books.created_at DESC')` に変更

## テストコード
- requests/users_spec.rb、system/users_spec.rbにて上記に関連した書籍一覧の修正を実施

# ユーザーストーリー
- 修正前の挙動(booksテーブルのレコードで古い順になっている)
![recommends-19-1](https://user-images.githubusercontent.com/64336740/119277859-f64a2700-bc5c-11eb-9174-12a83acc2f41.gif)

- 修正後の挙動(user_booksテーブルのレコードで新しい順になっている)
![recommends-19-2](https://user-images.githubusercontent.com/64336740/119277861-fa764480-bc5c-11eb-98e5-1b872f980f2f.gif)

# 関連するIssue
https://github.com/togo-mentor/my_recommended_books/issues/27

# プルリク提出時の確認事項
下記全てにチェック（x）をつけてから提出しましょう。
## コーディングの品質向上
- [x] **1.コメント**：初心者エンジニアにも分かりやすいような、相手目線でのコメントを書いた。
- [x] **2.テスト**：ユースケースが追加/変更された場合は、それに対して変更に強いテストを書いた。
## プルリクの品質向上
- [x] **3.UIのキャプチャ**：UIに変更がある場合は、変更点が分かりやすく伝わるように、キャプチャを貼っている。