### PR TITLE
Slack通知の実装

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -34,7 +34,7 @@ Metrics/AbcSize:
 
 # メソッドの中身が複雑になっていないか、Rubocopが計算して基準値を超えると警告を出す
 Metrics/PerceivedComplexity:
-   Max: 8
+   Max: 10
 
 # 循環的複雑度が高すぎないかをチェック（ifやforなどを1メソッド内で使いすぎている）
 Metrics/CyclomaticComplexity:

--- a/Gemfile
+++ b/Gemfile
@@ -76,3 +76,4 @@ gem 'rails_same_site_cookie' # cookieにsecure属性(HTTPSのみ受け付ける)
 group :production do
   gem 'unicorn', '5.4.1'
 end
+gem 'slack-ruby-client'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -133,10 +133,26 @@ GEM
       railties (>= 5.0.0)
     faker (2.17.0)
       i18n (>= 1.6, < 2)
+    faraday (1.4.3)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
+      multipart-post (>= 1.2, < 3)
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
+    faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.1.0)
+    faraday_middleware (1.0.0)
+      faraday (~> 1.0)
     ffi (1.15.0)
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
+    gli (2.20.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     hashie (4.1.0)
@@ -289,6 +305,7 @@ GEM
     ruby-progressbar (1.11.0)
     ruby-vips (2.1.0)
       ffi (~> 1.12)
+    ruby2_keywords (0.0.4)
     ruby_dep (1.5.0)
     rubyzip (2.3.0)
     sass (3.7.4)
@@ -306,6 +323,12 @@ GEM
       childprocess (>= 0.5, < 4.0)
       rubyzip (>= 1.2.2)
     simple_oauth (0.3.1)
+    slack-ruby-client (0.17.0)
+      faraday (>= 1.0)
+      faraday_middleware
+      gli
+      hashie
+      websocket-driver
     spring (2.1.1)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -399,6 +422,7 @@ DEPENDENCIES
   rubocop
   sass-rails (~> 5)
   selenium-webdriver
+  slack-ruby-client
   spring
   spring-watcher-listen (~> 2.0.0)
   turbolinks (~> 5)

--- a/app/controllers/api/v1/books_controller.rb
+++ b/app/controllers/api/v1/books_controller.rb
@@ -30,6 +30,7 @@ module Api
           @user.books << @book # ユーザーと書籍を紐付ける。
           render status: 201, json: { book: @book } # ステータスは手動で入れないと反映されない。リソース保存時のステータスは201
           post_tweet  # ツイートの投稿。書籍追加失敗時にツイートされるのを防ぐ
+          SlackNotification.new.notify_book_post(@book) if @user.is_admin
         end
       end
 

--- a/app/controllers/api/v1/books_controller.rb
+++ b/app/controllers/api/v1/books_controller.rb
@@ -30,7 +30,7 @@ module Api
           @user.books << @book # ユーザーと書籍を紐付ける。
           render status: 201, json: { book: @book } # ステータスは手動で入れないと反映されない。リソース保存時のステータスは201
           post_tweet  # ツイートの投稿。書籍追加失敗時にツイートされるのを防ぐ
-          SlackNotification.new.notify_book_post(@book) if Rails.env.production? && @user.is_admin
+          SlackNotification.notify_book_post(@book) if @user.is_admin
         end
       end
 

--- a/app/controllers/api/v1/books_controller.rb
+++ b/app/controllers/api/v1/books_controller.rb
@@ -30,7 +30,7 @@ module Api
           @user.books << @book # ユーザーと書籍を紐付ける。
           render status: 201, json: { book: @book } # ステータスは手動で入れないと反映されない。リソース保存時のステータスは201
           post_tweet  # ツイートの投稿。書籍追加失敗時にツイートされるのを防ぐ
-          SlackNotification.new.notify_book_post(@book) if @user.is_admin
+          SlackNotification.new.notify_book_post(@book) if Rails.env.production? && @user.is_admin
         end
       end
 

--- a/app/controllers/api/v1/outputs_controller.rb
+++ b/app/controllers/api/v1/outputs_controller.rb
@@ -36,7 +36,7 @@ module Api
           # ステータスは手動で設定する。リソース保存時のステータスは201
           render status: 201, json: { awareness: output_save_result[:awareness], action_plans: output_save_result[:action_plans] }
           post_tweet(@book) if @twitter_client && params[:to_be_shared_on_twitter]
-          puts @user
+          puts @user.is_admin
           SlackNotification.notify_output_post(@book, @output) if @user.is_admin
         else
           render status: 422, json: { errors: @output.errors.full_messages } # バリデーションに引っかかった際のステータスは422(Unprocessable entity)

--- a/app/controllers/api/v1/outputs_controller.rb
+++ b/app/controllers/api/v1/outputs_controller.rb
@@ -36,6 +36,7 @@ module Api
           # ステータスは手動で設定する。リソース保存時のステータスは201
           render status: 201, json: { awareness: output_save_result[:awareness], action_plans: output_save_result[:action_plans] }
           post_tweet(@book) if @twitter_client && params[:to_be_shared_on_twitter]
+          puts @user
           SlackNotification.notify_output_post(@book, @output) if @user.is_admin
         else
           render status: 422, json: { errors: @output.errors.full_messages } # バリデーションに引っかかった際のステータスは422(Unprocessable entity)

--- a/app/controllers/api/v1/outputs_controller.rb
+++ b/app/controllers/api/v1/outputs_controller.rb
@@ -36,7 +36,7 @@ module Api
           # ステータスは手動で設定する。リソース保存時のステータスは201
           render status: 201, json: { awareness: output_save_result[:awareness], action_plans: output_save_result[:action_plans] }
           post_tweet(@book) if @twitter_client && params[:to_be_shared_on_twitter]
-          SlackNotification.new.notify_output_post(@book, @output)
+          SlackNotification.new.notify_output_post(@book, @output) if Rails.env.production? && @user.is_admin
         else
           render status: 422, json: { errors: @output.errors.full_messages } # バリデーションに引っかかった際のステータスは422(Unprocessable entity)
         end

--- a/app/controllers/api/v1/outputs_controller.rb
+++ b/app/controllers/api/v1/outputs_controller.rb
@@ -36,7 +36,7 @@ module Api
           # ステータスは手動で設定する。リソース保存時のステータスは201
           render status: 201, json: { awareness: output_save_result[:awareness], action_plans: output_save_result[:action_plans] }
           post_tweet(@book) if @twitter_client && params[:to_be_shared_on_twitter]
-          SlackNotification.new.notify_output_post(@book, @output) if Rails.env.production? && @user.is_admin
+          SlackNotification.notify_output_post(@book, @output) if @user.is_admin
         else
           render status: 422, json: { errors: @output.errors.full_messages } # バリデーションに引っかかった際のステータスは422(Unprocessable entity)
         end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -4,8 +4,6 @@ class Book < ApplicationRecord
   with_options presence: true do
     # 以下は楽天ブックスAPIから取得
     validates :title
-    validates :author
-    validates :author_kana
     validates :publisher_name
     validates :sales_date
     validates :item_price

--- a/app/services/slack_notification.rb
+++ b/app/services/slack_notification.rb
@@ -4,7 +4,7 @@ class SlackNotification
 
   def self.notify_book_post(book)
     text = ''
-    text = "※API連携のテストです\n" if !Rails.env.production?
+    text += "※API連携のテストです\n" if !Rails.env.production?
     text += "*『#{book.title}』を推薦図書に追加しました！*\n"
     text += "著者：#{book.author}\n"
     text += "出版社：#{book.publisher_name}\n"
@@ -14,7 +14,7 @@ class SlackNotification
 
   def self.notify_output_post(book, output) 
     text = ''
-    text = "※API連携のテストです\n" if !Rails.env.production?
+    text += "※API連携のテストです\n" if !Rails.env.production?
     text += "*『#{book.title}』のアウトプットを投稿しました！*\n\n"
     text += "`気づき`\n"
     text += "```#{output.content}```\n"

--- a/app/services/slack_notification.rb
+++ b/app/services/slack_notification.rb
@@ -1,19 +1,18 @@
 class SlackNotification
   
-  def initialize
-    @client = Slack::Web::Client.new
-  end
+  @@client = Slack::Web::Client.new
 
-  def notify_book_post(book)
+  def self.notify_book_post(book)
     text = ''
+    text = '※API連携のテストです' if !Rails.env.production?
     text += "*『#{book.title}』を推薦図書に追加しました！*\n"
     text += "著者：#{book.author}\n"
     text += "出版社：#{book.publisher_name}\n"
     text += "楽天ブックスURL：#{book.item_url}\n"
-    @client.chat_postMessage(text: text, channel: "#毛利タニア国王の書斎")
+    @@client.chat_postMessage(text: text, channel: "#毛利タニア国王の書斎")
   end
 
-  def notify_output_post(book, output) 
+  def self.notify_output_post(book, output) 
     text = ''
     text += "*『#{book.title}』のアウトプットを投稿しました！*\n\n"
     text += "`気づき`\n"
@@ -28,6 +27,6 @@ class SlackNotification
       text += "#{action_plan[:how_to_do]}```\n"
     end
     text += "`書籍購入ページURL`\n#{book.item_url}\n"
-    @client.chat_postMessage(text: text, channel: "#毛利タニア国王の書斎")
+    @@client.chat_postMessage(text: text, channel: "#毛利タニア国王の書斎")
   end
 end

--- a/app/services/slack_notification.rb
+++ b/app/services/slack_notification.rb
@@ -10,10 +10,6 @@ class SlackNotification
     text += "著者：#{book.author}\n"
     text += "出版社：#{book.publisher_name}\n"
     text += "楽天ブックスURL：#{book.item_url}\n"
-    if Rails.env.production?
-      text += "↓その他の書籍を見るにはこちらから↓\n"
-      text += "#{Rails.application.routes.url_helpers.root_url(protocol: 'https')}books" 
-    end
     @client.chat_postMessage(text: text, channel: "#毛利タニア国王の書斎")
   end
 
@@ -32,10 +28,6 @@ class SlackNotification
       text += "#{action_plan[:how_to_do]}```\n"
     end
     text += "`書籍購入ページURL`\n#{book.item_url}\n"
-    if Rails.env.production?
-      text += "↓その他の書籍を見るにはこちらから↓\n"
-      text += "#{Rails.application.routes.url_helpers.root_url(protocol: 'https')}books/#{book.isbn}/outputs" 
-    end
     @client.chat_postMessage(text: text, channel: "#毛利タニア国王の書斎")
   end
 end

--- a/app/services/slack_notification.rb
+++ b/app/services/slack_notification.rb
@@ -1,6 +1,6 @@
 class SlackNotification
   
-  @@client = Slack::Web::Client.new
+  @client = Slack::Web::Client.new
 
   def self.notify_book_post(book)
     text = ''
@@ -9,7 +9,7 @@ class SlackNotification
     text += "著者：#{book.author}\n"
     text += "出版社：#{book.publisher_name}\n"
     text += "楽天ブックスURL：#{book.item_url}\n"
-    @@client.chat_postMessage(text: text, channel: "#毛利タニア国王の書斎")
+    @client.chat_postMessage(text: text, channel: "#毛利タニア国王の書斎")
   end
 
   def self.notify_output_post(book, output) 
@@ -27,6 +27,6 @@ class SlackNotification
       text += "#{action_plan[:how_to_do]}```\n"
     end
     text += "`書籍購入ページURL`\n#{book.item_url}\n"
-    @@client.chat_postMessage(text: text, channel: "#毛利タニア国王の書斎")
+    @client.chat_postMessage(text: text, channel: "#毛利タニア国王の書斎")
   end
 end

--- a/app/services/slack_notification.rb
+++ b/app/services/slack_notification.rb
@@ -4,7 +4,7 @@ class SlackNotification
 
   def self.notify_book_post(book)
     text = ''
-    text = '※API連携のテストです' if !Rails.env.production?
+    text = "※API連携のテストです\n" if !Rails.env.production?
     text += "*『#{book.title}』を推薦図書に追加しました！*\n"
     text += "著者：#{book.author}\n"
     text += "出版社：#{book.publisher_name}\n"
@@ -14,6 +14,7 @@ class SlackNotification
 
   def self.notify_output_post(book, output) 
     text = ''
+    text = "※API連携のテストです\n" if !Rails.env.production?
     text += "*『#{book.title}』のアウトプットを投稿しました！*\n\n"
     text += "`気づき`\n"
     text += "```#{output.content}```\n"

--- a/app/services/slack_notification.rb
+++ b/app/services/slack_notification.rb
@@ -1,0 +1,24 @@
+class SlackNotification
+
+  def initialize
+    @client = Slack::Web::Client.new
+  end
+
+  def notify_reading_output(output)
+    text = ''
+    @client.chat_postMessage(text: text, channel: "#毛利タニア国王の書斎")
+  end
+
+  def notify_book_post(book)
+    text = ''
+    text += "*『#{book.title}』を推薦図書に追加しました！*\n"
+    text += "著者：#{book.author}\n"
+    text += "出版社：#{book.publisher_name}\n"
+    text += "楽天ブックスURL：#{book.item_url}\n"
+    if Rails.env.production?
+      text += "↓その他の書籍を見るにはこちらから↓\n"
+      text += "#{Rails.application.routes.url_helpers.root_url(protocol: 'https')}books" 
+    end
+    @client.chat_postMessage(text: text, channel: "#毛利タニア国王の書斎")
+  end
+end

--- a/app/services/slack_notification.rb
+++ b/app/services/slack_notification.rb
@@ -1,5 +1,5 @@
 class SlackNotification
-
+  
   def initialize
     @client = Slack::Web::Client.new
   end
@@ -17,9 +17,7 @@ class SlackNotification
     @client.chat_postMessage(text: text, channel: "#毛利タニア国王の書斎")
   end
 
-  def notify_output_post(book, output)
-    
-    
+  def notify_output_post(book, output) 
     text = ''
     text += "*『#{book.title}』のアウトプットを投稿しました！*\n\n"
     text += "`気づき`\n"

--- a/app/services/slack_notification.rb
+++ b/app/services/slack_notification.rb
@@ -4,11 +4,6 @@ class SlackNotification
     @client = Slack::Web::Client.new
   end
 
-  def notify_reading_output(output)
-    text = ''
-    @client.chat_postMessage(text: text, channel: "#毛利タニア国王の書斎")
-  end
-
   def notify_book_post(book)
     text = ''
     text += "*『#{book.title}』を推薦図書に追加しました！*\n"
@@ -18,6 +13,30 @@ class SlackNotification
     if Rails.env.production?
       text += "↓その他の書籍を見るにはこちらから↓\n"
       text += "#{Rails.application.routes.url_helpers.root_url(protocol: 'https')}books" 
+    end
+    @client.chat_postMessage(text: text, channel: "#毛利タニア国王の書斎")
+  end
+
+  def notify_output_post(book, output)
+    
+    
+    text = ''
+    text += "*『#{book.title}』のアウトプットを投稿しました！*\n\n"
+    text += "`気づき`\n"
+    text += "```#{output.content}```\n"
+    output.action_plans.each.with_index(1) do |action_plan, index|
+      text += "`アクションプラン#{index}`\n"
+      text += "```- 内容\n"
+      text += "#{action_plan[:what_to_do]}\n"
+      text += "- いつやるか\n"
+      text += "#{action_plan[:time_of_execution]}\n"
+      text += "- 実施方法/達成基準\n"
+      text += "#{action_plan[:how_to_do]}```\n"
+    end
+    text += "`書籍購入ページURL`\n#{book.item_url}\n"
+    if Rails.env.production?
+      text += "↓その他の書籍を見るにはこちらから↓\n"
+      text += "#{Rails.application.routes.url_helpers.root_url(protocol: 'https')}books/#{book.isbn}/outputs" 
     end
     @client.chat_postMessage(text: text, channel: "#毛利タニア国王の書斎")
   end

--- a/config/initializers/slack_ruby_client.rb
+++ b/config/initializers/slack_ruby_client.rb
@@ -1,0 +1,3 @@
+Slack.configure do |config|
+  config.token = ENV['BOT_USER_ACCESS_TOKEN']
+end

--- a/spec/models/book_spec.rb
+++ b/spec/models/book_spec.rb
@@ -18,16 +18,6 @@ RSpec.describe Book, type: :model do
       book.valid?
       expect(book.errors.full_messages).to include "Title can't be blank"
     end
-    it 'authorが空の場合登録できない' do
-      book.author = ''
-      book.valid?
-      expect(book.errors.full_messages).to include "Author can't be blank"
-    end
-    it 'author_kanaが空の場合登録できない' do
-      book.author_kana = ''
-      book.valid?
-      expect(book.errors.full_messages).to include "Author kana can't be blank"
-    end
     it 'publisher_nameが空の場合登録できない' do
       book.publisher_name = ''
       book.valid?

--- a/spec/requests/books_spec.rb
+++ b/spec/requests/books_spec.rb
@@ -150,7 +150,6 @@ RSpec.describe 'Books', type: :request do
     context '書籍が投稿できる時' do
       before do
         user.save # uidを取り出すために保存
-        @headers = { uid: user.uid } # ユーザーと書籍を紐付ける処理ではrequest.headersからuidを抜き出しているため
       end
 
       it 'パラメータが正しければリクエストに成功する' do
@@ -202,8 +201,6 @@ RSpec.describe 'Books', type: :request do
       before do
         user.is_admin = true
         user.save # uidを取り出すために保存
-        @headers = { uid: user.uid } # ユーザーと書籍を紐付ける処理ではrequest.headersからuidを抜き出しているため
-        sleep 1
       end
 
       it "書籍の投稿に成功した場合Slackに通知される" do

--- a/spec/requests/books_spec.rb
+++ b/spec/requests/books_spec.rb
@@ -203,6 +203,7 @@ RSpec.describe 'Books', type: :request do
         user.is_admin = true
         user.save # uidを取り出すために保存
         @headers = { uid: user.uid } # ユーザーと書籍を紐付ける処理ではrequest.headersからuidを抜き出しているため
+        sleep 1
       end
 
       it "書籍の投稿に成功した場合Slackに通知される" do

--- a/spec/requests/outputs_spec.rb
+++ b/spec/requests/outputs_spec.rb
@@ -310,8 +310,8 @@ RSpec.describe 'Outputs', type: :request do
 
     context "管理者ユーザーで投稿した時" do
       before do
-        user.update(is_admin: true)
-        user.reload
+        user.is_admin = true
+        user.save # uidを取り出すために保存
       end
 
       it "書籍の投稿に成功した場合Slackに通知される" do

--- a/spec/requests/outputs_spec.rb
+++ b/spec/requests/outputs_spec.rb
@@ -310,6 +310,8 @@ RSpec.describe 'Outputs', type: :request do
 
     context "管理者ユーザーで投稿した時" do
       before do
+        one_action_plan = output_params[:action_plans].slice(0, 1)
+        output_params[:action_plans] = one_action_plan
         user.is_admin = true
         user.save # uidを取り出すために保存
       end

--- a/spec/requests/outputs_spec.rb
+++ b/spec/requests/outputs_spec.rb
@@ -314,13 +314,13 @@ RSpec.describe 'Outputs', type: :request do
         user.save # uidを取り出すために保存
       end
 
-      it "書籍の投稿に成功した場合Slackに通知される" do
+      it "アウトプットの投稿に成功した場合Slackに通知される" do
         allow(SlackNotification).to receive(:notify_output_post).and_return(true)
         post api_v1_book_outputs_path(book.isbn), xhr: true, params: { output: output_params }, headers: headers
         expect(SlackNotification).to have_received(:notify_output_post).once        
       end
 
-      it "書籍の投稿に失敗した場合Slackに通知されない" do
+      it "アウトプットの投稿に失敗した場合Slackに通知されない" do
         allow(SlackNotification).to receive(:notify_output_post).and_return(true)
         output_params[:content] = ''
         post api_v1_book_outputs_path(book.isbn), xhr: true, params: { output: output_params }, headers: headers

--- a/spec/requests/outputs_spec.rb
+++ b/spec/requests/outputs_spec.rb
@@ -306,5 +306,26 @@ RSpec.describe 'Outputs', type: :request do
         end
       end
     end
+
+
+    context "管理者ユーザーで投稿した時" do
+      before do
+        user.update(is_admin: true)
+        user.reload
+      end
+
+      it "書籍の投稿に成功した場合Slackに通知される" do
+        allow(SlackNotification).to receive(:notify_output_post).and_return(true)
+        post api_v1_book_outputs_path(book.isbn), xhr: true, params: { output: output_params }, headers: headers
+        expect(SlackNotification).to have_received(:notify_output_post).once        
+      end
+
+      it "書籍の投稿に失敗した場合Slackに通知されない" do
+        allow(SlackNotification).to receive(:notify_output_post).and_return(true)
+        output_params[:content] = ''
+        post api_v1_book_outputs_path(book.isbn), xhr: true, params: { output: output_params }, headers: headers
+        expect(SlackNotification).to have_received(:notify_output_post).exactly(0).times        
+      end
+    end
   end
 end

--- a/spec/system/books_spec.rb
+++ b/spec/system/books_spec.rb
@@ -288,7 +288,7 @@ RSpec.describe 'Books', type: :system do
         expect(page).to have_content 'その書籍はすでに追加されています'
       end
 
-      it '管理者でログイン時に書籍を追加に失敗するとSlackに通知されない' do
+      it '管理者でログイン時に書籍の追加に失敗するとSlackに通知されない' do
         user.is_admin = true
         sign_in(user) # ログインする
         allow(SlackNotification).to receive(:notify_book_post).and_return(true)

--- a/spec/system/books_spec.rb
+++ b/spec/system/books_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe 'Books', type: :system do
       it 'ログイン時にトップページにアクセスするとすでに投稿された書籍が新しい順に12件一覧で表示されている' do
         sign_in(user) # ログインする
         expect(page).to have_content '新着書籍一覧'
-        sleep 3
+        sleep 2
         # どれだけ投稿しても1ページ目に表示されるのは12件
         expect(all('.book-list-item').length).to  eq 12
         # 新しい順になっていることを検証
@@ -44,7 +44,7 @@ RSpec.describe 'Books', type: :system do
         create_list(:book, 6)
         sign_in(user) # ログインする
         expect(page).to have_content '新着書籍一覧'
-        sleep 3
+        sleep 2
         # 12件に満たない場合は今ある分がすべて出てくる
         expect(all('.book-list-item').length).to eq 6
       end
@@ -53,14 +53,14 @@ RSpec.describe 'Books', type: :system do
         Book.delete_all
         sign_in(user) # ログインする
         expect(page).to have_content '新着書籍一覧'
-        sleep 3
+        sleep 2
         expect(all('.book-list-item').length).to eq 0
       end
 
       it '新しく書籍を追加しても一覧の表示数は12件であり、一番上に最新の投稿が追加される' do
         sign_in(user) # ログインする
         expect(page).to have_content '新着書籍一覧'
-        sleep 3
+        sleep 2
         expect(all('.book-list-item').length).to eq 12
         click_link href: '/books/new'
         expect(page).to  have_content '推薦図書を投稿する'
@@ -73,7 +73,7 @@ RSpec.describe 'Books', type: :system do
         new_book_title = all('#search_result h3')[0].text
         expect do
           find('input[type="submit"]').click
-          sleep 4
+          sleep 2
         end.to change(user.books, :count).by(1) # ユーザーと紐付いているかどうかも検証
         expect(page).not_to have_content '推薦図書を投稿する' # トップページに戻ることを検証
         # 書籍を追加しても表示されるのは12件
@@ -90,7 +90,7 @@ RSpec.describe 'Books', type: :system do
         visit root_path
         expect(page).to have_content 'Kaidoku - 会読' # welcomeページにいることを検証
         click_link 'みんなのアウトプットを見る' # welcomeページから一覧へのリンク
-        sleep 3
+        sleep 2
         expect(page).to have_content '新着書籍一覧' # 一覧にいるかどうか検証
         # 同じく1ページ目には12件しか表示されていない
         expect(all('.book-list-item').length).to eq 12
@@ -102,7 +102,7 @@ RSpec.describe 'Books', type: :system do
         visit root_path
         expect(page).to have_content 'Kaidoku - 会読'
         click_link 'みんなのアウトプットを見る'
-        sleep 3
+        sleep 2
         expect(page).to have_content '新着書籍一覧'
         expect(all('.book-list-item').length).to  eq 12
       end
@@ -129,7 +129,7 @@ RSpec.describe 'Books', type: :system do
         find('a', text: '>').click
         find('a', text: '<').click
         # 1,2冊目が表示されているか検証
-        sleep 5
+        sleep 2
         expect(all('.book-title')[0].text).to  eq @book_list[14].title
         expect(all('.book-title')[1].text).to  eq @book_list[13].title
         expect(page).to have_content '>'
@@ -139,7 +139,7 @@ RSpec.describe 'Books', type: :system do
         find('a', text: '>').click
         find('a', text: '1').click
         # 1,2冊目が表示されているか検証
-        sleep 3
+        sleep 2
         expect(all('.book-title')[0].text).to  eq @book_list[14].title
         expect(all('.book-title')[1].text).to  eq @book_list[13].title
         expect(page).to have_content '>'
@@ -220,7 +220,7 @@ RSpec.describe 'Books', type: :system do
         all('#search_result > div')[0].click
         expect do
           find('input[type="submit"]').click
-          sleep 3
+          sleep 2
         end.to change(another_user.books, :count).by(1).and change(user.books, :count).by(0) # 投稿したユーザーにのみ紐付いているかどうか検証
         expect(page).not_to have_content '推薦図書を投稿する' # トップページに戻ることを検証
       end
@@ -252,6 +252,7 @@ RSpec.describe 'Books', type: :system do
         expect(page).to  have_content '推薦図書を投稿する'
         fill_in 'keyword',	with: 'test'
         find('.search-button').click
+        sleep 2
         expect(all('#search_result > div').length).not_to eq 0 # 検索結果が0件ではないことを検証
         expect do
           find('input[type="submit"]').click # 書籍を選択せずに送信
@@ -296,6 +297,7 @@ RSpec.describe 'Books', type: :system do
         expect(page).to  have_content '推薦図書を投稿する'
         fill_in 'keyword',	with: 'test'
         find('.search-button').click
+        sleep 2
         expect(all('#search_result > div').length).not_to eq 0 # 検索結果が0件ではないことを検証
         expect do
           find('input[type="submit"]').click # 書籍を選択せずに送信
@@ -344,13 +346,13 @@ RSpec.describe 'Books', type: :system do
       it 'ログイン中のユーザーは書籍が推薦図書に追加されていない場合アウトプット一覧から推薦図書を追加できる' do
         sign_in(user) # ログインする
         expect(page).to have_content '新着書籍一覧'
-        sleep 3
+        sleep 2
         all('a', text: 'アウトプット一覧')[-1].click
         expect(page).to  have_content "『#{book.title}』のアウトプット"
         expect(page).to  have_selector 'a', text: '推薦図書に追加する'
         expect do
           find('a', text: '推薦図書に追加する').click
-          sleep 3
+          sleep 2
         end.to change(user.books, :count).by(1)
         expect(page).not_to have_selector 'a', text: '推薦図書に追加する'
         expect(page).to have_link 'アウトプットを投稿する'
@@ -369,6 +371,7 @@ RSpec.describe 'Books', type: :system do
         expect(page).to have_content '新着書籍一覧' # 一覧にいるかどうか検証
         fill_in 'keyword', with: 'test'
         find('.search-button').click
+        sleep 2
         expect(all('.book-list-item').length).not_to eq 0
       end
 
@@ -376,6 +379,7 @@ RSpec.describe 'Books', type: :system do
         expect(page).to have_content '新着書籍一覧' # 一覧にいるかどうか検証
         fill_in 'keyword', with: 'test'
         find('.search-button').click
+        sleep 2
         expect(all('.book-list-item').length).to eq 12 # どれだけ投稿しても1ページ目に表示されるのは12件
         first_page_book = all('.book-list-item')[0]
         find('a', text: '>').click
@@ -387,6 +391,7 @@ RSpec.describe 'Books', type: :system do
         expect(page).to  have_content '新着書籍一覧' # 一覧にいるかどうか検証
         fill_in 'keyword', with: 'test'
         find('.search-button').click
+        sleep 2
         expect(all('.book-list-item').length).to eq 12 # どれだけ投稿しても1ページ目に表示されるのは12件
         first_page_book = all('.book-list-item')[0]
         find('a', text: '2').click
@@ -399,6 +404,7 @@ RSpec.describe 'Books', type: :system do
         expect(page).to  have_content @book_list[14].title # 新着順なので一番うしろのデータが先頭に来る
         fill_in 'keyword', with: 'test'
         find('.search-button').click
+        sleep 2
         expect(page).not_to have_content @book_list[14].title # 1ページ目にあった書籍は表示されない。
       end
 
@@ -406,10 +412,12 @@ RSpec.describe 'Books', type: :system do
         expect(page).to have_content '新着書籍一覧' # 一覧にいるかどうか検証
         fill_in 'keyword', with: 'test'
         find('.search-button').click
+        sleep 2
         title_search_result = all('.book-list-item')[0] # タイトル検索した際の先頭の要素を変数化しておく
         select '著者名'
         fill_in 'keyword', with: 'test'
         find('.search-button').click
+        sleep 2
         expect(page).not_to have_content title_search_result # タイトル検索したときの内容が消えている
       end
 
@@ -417,14 +425,14 @@ RSpec.describe 'Books', type: :system do
         expect(page).to have_content '新着書籍一覧' # 一覧にいるかどうか検証
         fill_in 'keyword', with: ''
         find('.search-button').click
-        sleep 7
+        sleep 2
         expect(page.driver.browser.switch_to.alert.text).to eq 'タイトルを入力してください'
         sleep 2
         page.driver.browser.switch_to.alert.accept
         select '著者名'
         fill_in 'keyword', with: ''
         find('.search-button').click
-        sleep 5
+        sleep 2
         expect(page.driver.browser.switch_to.alert.text).to eq '著者名を入力してください'
         sleep 2
         page.driver.browser.switch_to.alert.accept
@@ -434,7 +442,7 @@ RSpec.describe 'Books', type: :system do
         expect(page).to have_content '新着書籍一覧' # 一覧にいるかどうか検証
         fill_in 'keyword', with: ' ほげほげふが'
         find('.search-button').click
-        sleep 7
+        sleep 2
         expect(page.driver.browser.switch_to.alert.text).to eq '検索結果が見つかりませんでした'
         sleep 2
         page.driver.browser.switch_to.alert.accept
@@ -451,10 +459,11 @@ RSpec.describe 'Books', type: :system do
         expect(page).to  have_content 'ログイン'
         expect(page).to  have_content 'Kaidoku - 会読' # welcomeページにいることを検証
         click_link 'みんなのアウトプットを見る' # welcomeページから一覧へのリンク
-        sleep 3
+        sleep 2
         expect(page).to have_content '新着書籍一覧' # 一覧にいるかどうか検証
         fill_in 'keyword', with: 'test'
         find('.search-button').click
+        sleep 2
         expect(all('.book-list-item').length).not_to eq 0
       end
     end
@@ -466,13 +475,13 @@ RSpec.describe 'Books', type: :system do
         expect(page).to  have_content '推薦図書を投稿する'
         fill_in 'keyword',	with: 'test'
         find('.search-button').click
-        sleep 5
+        sleep 2
         expect(all('#search_result > div').length).not_to eq 0 # 検索結果が0件ではないことを検証
         title_search_result = all('#search_result h3')[0].text
         select '著者名'
         fill_in 'keyword', with: 'test'
         find('.search-button').click
-        sleep 5
+        sleep 2
         expect(page).not_to have_content title_search_result
       end
 
@@ -482,7 +491,7 @@ RSpec.describe 'Books', type: :system do
         expect(page).to  have_content '推薦図書を投稿する'
         fill_in 'keyword',	with: ''
         find('.search-button').click
-        sleep 5
+        sleep 2
         expect(page.driver.browser.switch_to.alert.text).to eq 'タイトルを入力してください'
         sleep 2
         page.driver.browser.switch_to.alert.accept
@@ -491,7 +500,7 @@ RSpec.describe 'Books', type: :system do
         select '著者名'
         fill_in 'keyword', with: ''
         find('.search-button').click
-        sleep 5
+        sleep 2
         expect(page.driver.browser.switch_to.alert.text).to eq '著者名を入力してください'
         sleep 2
         page.driver.browser.switch_to.alert.accept
@@ -506,7 +515,7 @@ RSpec.describe 'Books', type: :system do
         expect(page).to  have_content '推薦図書を投稿する'
         fill_in 'keyword',	with: 'hogefugahoge'
         find('.search-button').click
-        sleep 5
+        sleep 2
         expect(page.driver.browser.switch_to.alert.text).to eq '検索結果が見つかりませんでした'
         sleep 2
         page.driver.browser.switch_to.alert.accept


### PR DESCRIPTION
# 実装概要
- 管理者権限で投稿した際にSlackに通知する機能を実装
- 著者名、著者名カナを必須としていたが必須ではない形に変更

# 実装の目的
読書記録をアプリにアクセスしなくても見ることができる状態にするため

# ユーザーストーリー
1. 管理者権限」(is_admin=true)のユーザーでログイン
2.書籍の追加もしくはアウトプットの投稿
3. Slackに投稿内容が通知される

# issue
https://github.com/togo-mentor/my_recommended_books/issues/36

# 動作確認
ローカルで実際に管理者権限のユーザーを作成して投稿をテスト
Slack通知内容
- 書籍追加の場合
<img width="496" alt="Slack___毛利タニア国王の書斎___div_alumni_unofficial" src="https://user-images.githubusercontent.com/64336740/124993354-39caea00-e07f-11eb-9928-5fc80d4d3d1c.png">

- アウトプット投稿の場合
<img width="503" alt="Slack___毛利タニア国王の書斎___div_alumni_unofficial" src="https://user-images.githubusercontent.com/64336740/124993414-4d765080-e07f-11eb-95af-a30b9741d268.png">

# プルリク提出時の確認事項
下記全てにチェック（x）をつけてから提出しましょう。
## コーディングの品質向上
- [x] **1.コメント**：初心者エンジニアにも分かりやすいような、相手目線でのコメントを書いた。
- [x] **2.テスト**：ユースケースが追加/変更された場合は、それに対して変更に強いテストを書いた。
## プルリクの品質向上
- [x] **3.UIのキャプチャ**：UIに変更がある場合は、変更点が分かりやすく伝わるように、キャプチャを貼っている。
